### PR TITLE
Added workload status flag file

### DIFF
--- a/azure_li_services/network.py
+++ b/azure_li_services/network.py
@@ -29,11 +29,8 @@ class AzureHostedNetworkSetup(object):
     Implements methods to create Network interface configuration files
     """
     def __init__(self, network):
-        if (
-            'ip' not in network or
-            'interface' not in network or
-            'subnet_mask' not in network
-        ):
+        if 'ip' not in network or 'interface' not in network or \
+           'subnet_mask' not in network:
             raise AzureHostedNetworkConfigDataException(
                 'At least one of {0} missing in {1}'.format(
                     ('ip', 'interface', 'subnet_mask'), network

--- a/azure_li_services/units/cleanup.py
+++ b/azure_li_services/units/cleanup.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+
 # project
 from azure_li_services.command import Command
 from azure_li_services.defaults import Defaults
@@ -30,14 +32,31 @@ def main():
     service_reports = Defaults.get_service_reports()
 
     reboot_system = False
+    all_services_successful = True
     for report in service_reports:
         if not report.get_state():
             # in case a service has unknown or failed state we will
             # not consider to reboot the machine
+            all_services_successful = False
             reboot_system = False
             break
         if report.get_reboot():
             reboot_system = True
+
+    install_source = Defaults.mount_config_source()
+    try:
+        state_file = os.sep.join(
+            [
+                install_source.location,
+                'workload_success_is_{}'.format(
+                    all_services_successful
+                ).lower()
+            ]
+        )
+        with open(state_file, 'w'):
+            pass
+    finally:
+        Defaults.umount_config_source(install_source)
 
     Command.run(
         [

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,5 @@ testpaths = test/unit/
 [flake8]
 exclude = .tox*/*
 # we allow long lines
-ignore = E501
+# we ignore warnings about quoting of escape sequences (W605)
+ignore = E501, W605

--- a/test/unit/units/cleanup_test.py
+++ b/test/unit/units/cleanup_test.py
@@ -8,19 +8,34 @@ from azure_li_services.units.cleanup import main
 class TestCleanup(object):
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.cleanup.Defaults.get_service_reports')
-    def test_main(self, mock_get_service_reports, mock_Command_run):
+    @patch('azure_li_services.units.cleanup.Defaults.mount_config_source')
+    @patch('azure_li_services.units.cleanup.Defaults.umount_config_source')
+    def test_main(
+        self, mock_umount_config_source, mock_mount_config_source,
+        mock_get_service_reports, mock_Command_run
+    ):
         report = Mock()
         report.get_state.return_value = True
         report.get_reboot.return_value = True
         mock_get_service_reports.return_value = [report]
         with patch('builtins.open', create=True) as mock_open:
+            install_source = Mock()
+            install_source.location = 'lun_location'
+            mock_mount_config_source.return_value = install_source
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
             file_handle.read.return_value = \
                 'BOOT_IMAGE=/vmlinuz-4.4.138-59-default ' + \
                 'root=UUID=8ef42f26 splash=silent'
             main()
-            mock_open.assert_called_once_with('/proc/cmdline')
+            mock_mount_config_source.assert_called_once_with()
+            mock_umount_config_source.assert_called_once_with(
+                install_source
+            )
+            assert mock_open.call_args_list == [
+                call('lun_location/workload_success_is_true', 'w'),
+                call('/proc/cmdline')
+            ]
             assert mock_Command_run.call_args_list == [
                 call(
                     [
@@ -49,18 +64,19 @@ class TestCleanup(object):
             ]
         report.get_state.return_value = False
         mock_Command_run.reset_mock()
-        main()
-        assert mock_Command_run.call_args_list == [
-            call(
-                [
-                    'zypper', '--non-interactive',
-                    'remove', '--clean-deps', '--force-resolution',
-                    'azure-li-services'
-                ]
-            ),
-            call(
-                [
-                    'systemctl', 'reset-failed'
-                ]
-            )
-        ]
+        with patch('builtins.open', create=True) as mock_open:
+            main()
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'zypper', '--non-interactive',
+                        'remove', '--clean-deps', '--force-resolution',
+                        'azure-li-services'
+                    ]
+                ),
+                call(
+                    [
+                        'systemctl', 'reset-failed'
+                    ]
+                )
+            ]


### PR DESCRIPTION
At the time of the cleanup service a file named:

* ```workload_success_is_true```  or
* ```workload_success_is_false```

will be written on the storage location the config file was read from.

At the time this file appears it's also safe to release the config file storage location from the system.

This Fixes #93