### PR TITLE
Write workload log file

### DIFF
--- a/azure_li_services/units/cleanup.py
+++ b/azure_li_services/units/cleanup.py
@@ -55,6 +55,8 @@ def main():
         )
         with open(state_file, 'w'):
             pass
+        if not all_services_successful:
+            write_service_log(install_source)
     finally:
         Defaults.umount_config_source(install_source)
 
@@ -95,3 +97,15 @@ def get_boot_cmdline():
             effective_boot_options.append(option)
 
     return ' '.join(effective_boot_options)
+
+
+def write_service_log(install_source):
+    log_file = os.sep.join(
+        [install_source.location, 'workload.log']
+    )
+    bash_command = ' '.join(
+        ['systemctl', 'status', '-l', '--all', '&>', log_file]
+    )
+    Command.run(
+        ['bash', '-c', bash_command], raise_on_error=False
+    )

--- a/test/unit/units/cleanup_test.py
+++ b/test/unit/units/cleanup_test.py
@@ -69,6 +69,12 @@ class TestCleanup(object):
             assert mock_Command_run.call_args_list == [
                 call(
                     [
+                        'bash', '-c',
+                        'systemctl status -l --all &> lun_location/workload.log'
+                    ], raise_on_error=False
+                ),
+                call(
+                    [
                         'zypper', '--non-interactive',
                         'remove', '--clean-deps', '--force-resolution',
                         'azure-li-services'


### PR DESCRIPTION
In case of a deployment error, a log file in addition to the
status flag files is written which contains the systemd
service log information from all services ran so far.
The log file is written to the storage location from which
the yaml config file was read from. It is expected that
this location is writable and offers enough space to store
the logfile. In case of an error writing the log we will
treat this as "bad luck" and continue with the cleanup.
This Fixes #96