### PR TITLE
Support MTU setup for standard and vlan interfaces

### DIFF
--- a/azure_li_services/instance_type.py
+++ b/azure_li_services/instance_type.py
@@ -20,9 +20,10 @@ from collections import namedtuple
 
 class InstanceType(object):
     Constants = namedtuple(
-        'Constants', ['li', 'vli']
+        'Constants', ['li', 'vli', 'vli_gen3']
     )
-    constants = Constants('li', 'vli')
+    constants = Constants('li', 'vli', 'vli_gen3')
 
     li = constants.li
     vli = constants.vli
+    vli_gen3 = constants.vli_gen3

--- a/azure_li_services/network.py
+++ b/azure_li_services/network.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 import ipaddress
 from textwrap import dedent
 
@@ -61,6 +62,10 @@ class AzureHostedNetworkSetup(object):
                     netmask=self.network['subnet_mask']
                 )
             )
+            if 'mtu' in self.network:
+                ifcfg.write(
+                    'MTU={0}{1}'.format(self.network['mtu'], os.linesep)
+                )
 
     def create_default_route_config(self):
         """
@@ -118,6 +123,10 @@ class AzureHostedNetworkSetup(object):
                     netmask=self.network['subnet_mask']
                 )
             )
+            if 'vlan_mtu' in self.network:
+                ifcfg_vlan.write(
+                    'MTU={0}{1}'.format(self.network['vlan_mtu'], os.linesep)
+                )
 
     def create_bridge_config(self):
         """

--- a/azure_li_services/runtime_config.py
+++ b/azure_li_services/runtime_config.py
@@ -39,7 +39,7 @@ class RuntimeConfig(object):
 
     .. code:: yaml
         version: some_version_identifier
-        instance_type: LargeInstance|VeryLargeInstance
+        instance_type: LargeInstance|VeryLargeInstance|VeryLargeInstanceGen3
         sku: identifier_string
         hostname: name_string
 
@@ -51,9 +51,11 @@ class RuntimeConfig(object):
           -
             interface: eth0
             vlan: vlan_number
+            vlan_mtu: 1500
             ip: 10.250.10.51
             gateway: 10.250.10.1
             subnet_mask: 255.255.255.0
+            mtu: 9000
 
         storage:
           -
@@ -113,8 +115,11 @@ class RuntimeConfig(object):
 
     def get_instance_type(self):
         if self.config_data:
-            if self.config_data.get('instance_type') == 'VeryLargeInstance':
+            instance_type = self.config_data.get('instance_type')
+            if instance_type == 'VeryLargeInstance':
                 return InstanceType.vli
+            elif instance_type == 'VeryLargeInstanceGen3':
+                return InstanceType.vli_gen3
             else:
                 return InstanceType.li
 

--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -7,7 +7,7 @@ schema = {
         'required': True,
         'type': 'string',
         'nullable': False,
-        'regex': '^(LargeInstance|VeryLargeInstance)$'
+        'regex': '^(LargeInstance|VeryLargeInstance|VeryLargeInstanceGen3)$'
     },
     'sku': {
         'required': True,
@@ -63,6 +63,11 @@ schema = {
                     'required': False,
                     'type': 'number'
                 },
+                'vlan_mtu': {
+                    'required': False,
+                    'type': 'number',
+                    'nullable': False
+                },
                 'ip': {
                     'required': True,
                     'type': 'string'
@@ -74,6 +79,11 @@ schema = {
                 'subnet_mask': {
                     'required': True,
                     'type': 'string'
+                },
+                'mtu': {
+                    'required': False,
+                    'type': 'number',
+                    'nullable': False
                 }
             }
         }

--- a/azure_li_services/units/network.py
+++ b/azure_li_services/units/network.py
@@ -42,7 +42,7 @@ def main():
 
     if network_config:
         network_errors = []
-        if instance_type == InstanceType.li:
+        if instance_type is not InstanceType.vli_gen3:
             for network in network_config:
                 try:
                     li_network = AzureHostedNetworkSetup(network)

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -16,9 +16,11 @@ networking:
   -
     interface: eth0
     vlan: 10
+    vlan_mtu: 1500
     ip: 10.250.10.51
     gateway: 10.250.10.1
     subnet_mask: 255.255.255.0
+    mtu: 9000
 
 storage:
   -

--- a/test/data/config_vli_gen3.yaml
+++ b/test/data/config_vli_gen3.yaml
@@ -1,0 +1,45 @@
+version: "20180614"
+instance_type: VeryLargeInstanceGen3
+sku: "SR92"
+hostname: "azure"
+
+machine_constraints:
+  min_cores: 32
+  min_memory: "20tb"
+
+networking:
+  -
+    interface: eth0
+    ip: 10.250.10.51
+    subnet_mask: 255.255.255.0
+
+storage:
+  -
+    file_system: nfs
+    min_size:  112G
+    device: "10.250.21.12:/nfs/share"
+    mount: "/mnt/foo"
+    mount_options:
+      - a
+      - b
+      - c
+
+credentials:
+   -
+     username: hanauser
+     shadow_hash: "sha-512-cipher"
+     ssh-key: "ssh-rsa foo"
+   -
+     username: rpc
+     id: 495
+     group:
+       name: nogroup
+     home_dir: /var/lib/empty
+
+packages:
+  repository_name: azure_packages
+  directory:
+    - "/directory-with-rpm-files"
+    - "/another-directory-with-rpm-files"
+
+call: "path/to/executable/file"

--- a/test/unit/instance_type_test.py
+++ b/test/unit/instance_type_test.py
@@ -5,3 +5,4 @@ class TestInstanceType(object):
     def test_instance_type_names(self):
         assert InstanceType.li == 'li'
         assert InstanceType.vli == 'vli'
+        assert InstanceType.vli_gen3 == 'vli_gen3'

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -1,7 +1,7 @@
 import io
 from pytest import raises
 from unittest.mock import (
-    MagicMock, patch
+    MagicMock, patch, call
 )
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.network import AzureHostedNetworkSetup
@@ -25,12 +25,15 @@ class TestAzureHostedNetworkSetup(object):
             mock_open.assert_called_once_with(
                 '/etc/sysconfig/network/ifcfg-eth0', 'w'
             )
-            file_handle.write.assert_called_once_with(
-                'BOOTPROTO=static\n'
-                'BROADCAST=10.250.10.255\n'
-                'NETMASK=255.255.255.0\n'
-                'STARTMODE=auto\n'
-            )
+            assert file_handle.write.call_args_list == [
+                call(
+                    'BOOTPROTO=static\n'
+                    'BROADCAST=10.250.10.255\n'
+                    'NETMASK=255.255.255.0\n'
+                    'STARTMODE=auto\n'
+                ),
+                call('MTU=9000\n')
+            ]
 
     def test_create_default_route_config(self):
         with patch('builtins.open', create=True) as mock_open:
@@ -52,17 +55,20 @@ class TestAzureHostedNetworkSetup(object):
             mock_open.assert_called_once_with(
                 '/etc/sysconfig/network/ifcfg-eth0.10', 'w'
             )
-            file_handle.write.assert_called_once_with(
-                'BOOTPROTO=static\n'
-                'DEVICE=eth0.10\n'
-                'ETHERDEVICE=eth0\n'
-                'IPADDR=10.250.10.51\n'
-                'NETMASK=255.255.255.0\n'
-                'ONBOOT=yes\n'
-                'STARTMODE=auto\n'
-                'VLAN=yes\n'
-                'VLAN_ID=10\n'
-            )
+            assert file_handle.write.call_args_list == [
+                call(
+                    'BOOTPROTO=static\n'
+                    'DEVICE=eth0.10\n'
+                    'ETHERDEVICE=eth0\n'
+                    'IPADDR=10.250.10.51\n'
+                    'NETMASK=255.255.255.0\n'
+                    'ONBOOT=yes\n'
+                    'STARTMODE=auto\n'
+                    'VLAN=yes\n'
+                    'VLAN_ID=10\n'
+                ),
+                call('MTU=1500\n')
+            ]
 
     def test_create_vlan_config_skipped_on_missing_id(self):
         del self.network.network['vlan']

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -25,17 +25,23 @@ class TestRuntimeConfig(object):
 
     def test_get_instance_type(self):
         assert self.runtime_config.get_instance_type() == InstanceType.li
-        self.runtime_config.config_data['instance_type'] = 'VeryLargeInstance'
+        self.runtime_config.config_data['instance_type'] = \
+            'VeryLargeInstance'
         assert self.runtime_config.get_instance_type() == InstanceType.vli
+        self.runtime_config.config_data['instance_type'] = \
+            'VeryLargeInstanceGen3'
+        assert self.runtime_config.get_instance_type() == InstanceType.vli_gen3
 
     def test_get_network_config(self):
         assert self.runtime_config.get_network_config() == [
             {
                 'interface': 'eth0',
                 'vlan': 10,
+                'vlan_mtu': 1500,
                 'subnet_mask': '255.255.255.0',
                 'ip': '10.250.10.51',
-                'gateway': '10.250.10.1'
+                'gateway': '10.250.10.1',
+                'mtu': 9000
             }
         ]
 

--- a/test/unit/units/network_test.py
+++ b/test/unit/units/network_test.py
@@ -13,7 +13,7 @@ class TestNetwork(object):
     @patch('azure_li_services.units.network.AzureHostedNetworkSetup')
     @patch('azure_li_services.units.network.Defaults.get_config_file')
     @patch('azure_li_services.units.network.StatusReport')
-    def test_main_li_network(
+    def test_main_li_vli_network(
         self, mock_StatusReport, mock_get_config_file,
         mock_AzureHostedNetworkSetup
     ):
@@ -34,7 +34,9 @@ class TestNetwork(object):
 
     @patch('azure_li_services.units.network.Defaults.get_config_file')
     @patch('azure_li_services.units.network.StatusReport')
-    def test_main_vli_network(self, mock_StatusReport, mock_get_config_file):
-        mock_get_config_file.return_value = '../data/config_vli.yaml'
+    def test_main_vli_gen3_network(
+        self, mock_StatusReport, mock_get_config_file
+    ):
+        mock_get_config_file.return_value = '../data/config_vli_gen3.yaml'
         with raises(AzureHostedNetworkConfigDataException):
             main()


### PR DESCRIPTION
__Support Custom MTU setup__

Enhanced the config schema to allow the networking attributes mtu and vlan_mtu as optional arguments to configure the maximum transfer unit for the interface and/or its virtual type.

In addition add a differentiator for the VeryLarge instance types in generation 3 and its successor. For Gen3 VeryLarge instance types the network setup was not yet defined because we haven't started to support this target. However the successor of the VeryLarge instance type is similar in the infrastructure and boot compared to the LargeInstance type and can be covered by the network service in the same way. 

This Fixes #105