### PR TITLE
Fixup createrepo requirement

### DIFF
--- a/package/azure-li-services-spec-template
+++ b/package/azure-li-services-spec-template
@@ -36,7 +36,11 @@ Requires:         python3-Cerberus
 Requires:         shadow
 Requires(preun):  systemd
 Requires(postun): systemd
+%if 0%{?suse_version} > 1320
+Requires:         createrepo-implementation
+%else
 Requires:         createrepo
+%endif
 Requires:         zypper
 Requires:         rsync
 BuildArch:        noarch


### PR DESCRIPTION
createrepo is no longer part of SLE15. The successor of this
package is createrepo_c an implementation in C. Therefore
the requires statement in the spec file should be changed to
the generic provides name which is createrepo-implementation
such that the package requirements are valid for SLE12 and
SLE15 builds.