### PR TITLE
Added support for interface bonding

### DIFF
--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -57,7 +57,8 @@ schema = {
             'schema': {
                 'interface': {
                     'required': True,
-                    'type': 'string'
+                    'type': 'string',
+                    'nullable': False
                 },
                 'vlan': {
                     'required': False,
@@ -69,20 +70,33 @@ schema = {
                     'nullable': False
                 },
                 'ip': {
-                    'required': True,
-                    'type': 'string'
+                    'required': False,
+                    'type': 'string',
+                    'nullable': False
                 },
                 'gateway': {
                     'required': False,
-                    'type': 'string'
+                    'type': 'string',
+                    'nullable': False
                 },
                 'subnet_mask': {
-                    'required': True,
-                    'type': 'string'
+                    'required': False,
+                    'type': 'string',
+                    'nullable': False
                 },
                 'mtu': {
                     'required': False,
                     'type': 'number',
+                    'nullable': False
+                },
+                'bonding_slaves': {
+                    'required': False,
+                    'type': 'list',
+                    'nullable': False
+                },
+                'bonding_options': {
+                    'required': False,
+                    'type': 'list',
                     'nullable': False
                 }
             }

--- a/azure_li_services/units/network.py
+++ b/azure_li_services/units/network.py
@@ -48,6 +48,7 @@ def main():
                     li_network = AzureHostedNetworkSetup(network)
                     li_network.create_interface_config()
                     li_network.create_vlan_config()
+                    li_network.create_bond_config()
                     li_network.create_default_route_config()
                 except Exception as issue:
                     network_errors.append(issue)

--- a/test/data/config-net-bond.yaml
+++ b/test/data/config-net-bond.yaml
@@ -1,0 +1,27 @@
+version: "20180614"
+instance_type: LargeInstance
+sku: "SR92"
+
+networking:
+  -
+    interface: eth0
+
+  -
+    interface: eth1
+
+  -
+    interface: bond0
+    ip: 10.250.10.51
+    gateway: 10.250.10.1
+    subnet_mask: 255.255.255.0
+    bonding_slaves:
+      - eth0
+      - eth1
+    bonding_options:
+      - opt=val
+
+credentials:
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"

--- a/test/data/config-net-vlan-bond.yaml
+++ b/test/data/config-net-vlan-bond.yaml
@@ -1,0 +1,30 @@
+version: "20180614"
+instance_type: LargeInstance
+sku: "SR92"
+
+networking:
+  -
+    interface: eth0
+
+  -
+    interface: eth1
+
+  -
+    interface: bond0
+    vlan: 10
+    vlan_mtu: 1500
+    ip: 10.250.10.51
+    gateway: 10.250.10.1
+    subnet_mask: 255.255.255.0
+    bonding_slaves:
+      - eth0
+      - eth1
+    bonding_options:
+      - opt=value
+    mtu: 9000
+
+credentials:
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"

--- a/test/data/config-net-vlan.yaml
+++ b/test/data/config-net-vlan.yaml
@@ -1,0 +1,19 @@
+version: "20180614"
+instance_type: LargeInstance
+sku: "SR92"
+
+networking:
+  -
+    interface: eth0
+    vlan: 10
+    vlan_mtu: 1500
+    ip: 10.250.10.51
+    gateway: 10.250.10.1
+    subnet_mask: 255.255.255.0
+    mtu: 9000
+
+credentials:
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"

--- a/test/data/config-net.yaml
+++ b/test/data/config-net.yaml
@@ -1,0 +1,17 @@
+version: "20180614"
+instance_type: LargeInstance
+sku: "SR92"
+
+networking:
+  -
+    interface: eth0
+    ip: 10.250.10.51
+    gateway: 10.250.10.1
+    subnet_mask: 255.255.255.0
+    mtu: 9000
+
+credentials:
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -5,22 +5,38 @@ from unittest.mock import (
 )
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.network import AzureHostedNetworkSetup
-from azure_li_services.exceptions import AzureHostedNetworkConfigDataException
 
 
 class TestAzureHostedNetworkSetup(object):
     def setup(self):
-        config = RuntimeConfig('../data/config.yaml')
-        self.network = AzureHostedNetworkSetup(config.get_network_config()[0])
+        config_nic = RuntimeConfig('../data/config-net.yaml')
+        config_vlan = RuntimeConfig('../data/config-net-vlan.yaml')
+        config_bond = RuntimeConfig('../data/config-net-bond.yaml')
+        config_vlan_bond = RuntimeConfig('../data/config-net-vlan-bond.yaml')
 
-    def test_init_raises(self):
-        with raises(AzureHostedNetworkConfigDataException):
-            AzureHostedNetworkSetup({})
+        self.network_config = config_nic.get_network_config()
+        self.network_config_vlan = config_vlan.get_network_config()
+        self.network_config_bond = config_bond.get_network_config()
+        self.network_config_vlan_bond = config_vlan_bond.get_network_config()
 
-    def test_create_interface_config(self):
+    def test_create_default_route_config(self):
+        network = AzureHostedNetworkSetup(self.network_config[0])
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.network.create_interface_config()
+            network.create_default_route_config()
+            file_handle = mock_open.return_value.__enter__.return_value
+            mock_open.assert_called_once_with(
+                '/etc/sysconfig/network/ifroute-eth0', 'w'
+            )
+            file_handle.write.assert_called_once_with(
+                'default 10.250.10.1 - eth0\n'
+            )
+
+    def test_create_interface_config(self):
+        network = AzureHostedNetworkSetup(self.network_config[0])
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            network.create_interface_config()
             file_handle = mock_open.return_value.__enter__.return_value
             mock_open.assert_called_once_with(
                 '/etc/sysconfig/network/ifcfg-eth0', 'w'
@@ -28,29 +44,23 @@ class TestAzureHostedNetworkSetup(object):
             assert file_handle.write.call_args_list == [
                 call(
                     'BOOTPROTO=static\n'
-                    'BROADCAST=10.250.10.255\n'
-                    'NETMASK=255.255.255.0\n'
                     'STARTMODE=auto\n'
                 ),
+                call(
+                    'BROADCAST=10.250.10.255\n'
+                ),
+                call(
+                    'NETMASK=255.255.255.0\n'
+                ),
+                call('IPADDR=10.250.10.51\n'),
                 call('MTU=9000\n')
             ]
 
-    def test_create_default_route_config(self):
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.network.create_default_route_config()
-            file_handle = mock_open.return_value.__enter__.return_value
-            mock_open.assert_called_once_with(
-                '/etc/sysconfig/network/ifroute-eth0.10', 'w'
-            )
-            file_handle.write.assert_called_once_with(
-                'default 10.250.10.1 - eth0.10\n'
-            )
-
     def test_create_vlan_config(self):
+        network = AzureHostedNetworkSetup(self.network_config_vlan[0])
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.network.create_vlan_config()
+            network.create_vlan_config()
             file_handle = mock_open.return_value.__enter__.return_value
             mock_open.assert_called_once_with(
                 '/etc/sysconfig/network/ifcfg-eth0.10', 'w'
@@ -71,11 +81,92 @@ class TestAzureHostedNetworkSetup(object):
             ]
 
     def test_create_vlan_config_skipped_on_missing_id(self):
-        del self.network.network['vlan']
+        network = AzureHostedNetworkSetup(self.network_config[0])
         with patch('builtins.open', create=True) as mock_open:
-            self.network.create_vlan_config()
+            network.create_vlan_config()
             assert mock_open.called is False
 
     def test_create_bridge_config(self):
+        network = AzureHostedNetworkSetup(self.network_config[0])
         with raises(NotImplementedError):
-            self.network.create_bridge_config()
+            network.create_bridge_config()
+
+    def test_create_bond_config(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            for network_config in self.network_config_bond:
+                network = AzureHostedNetworkSetup(network_config)
+                network.create_interface_config()
+                network.create_bond_config()
+            assert file_handle.write.call_args_list == [
+                # eth0
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                # eth1
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                # bond0
+                call(
+                    'BOOTPROTO=none\n'
+                    'DEVICE=bond0\n'
+                    'ONBOOT=yes\n'
+                    'STARTMODE=auto\n'
+                    'BONDING_MASTER=yes\n'
+                ),
+                call('IPADDR=10.250.10.51\n'),
+                call('NETMASK=255.255.255.0\n'),
+                call('BONDING_MODULE_OPTS="opt=val"\n'),
+                call('BONDING_SLAVE0=eth0\n'),
+                call('BONDING_SLAVE1=eth1\n')
+            ]
+            assert mock_open.call_args_list == [
+                call('/etc/sysconfig/network/ifcfg-eth0', 'w'),
+                call('/etc/sysconfig/network/ifcfg-eth1', 'w'),
+                call('/etc/sysconfig/network/ifcfg-bond0', 'w')
+            ]
+
+    def test_create_vlan_bond_config(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            for network_config in self.network_config_vlan_bond:
+                network = AzureHostedNetworkSetup(network_config)
+                network.create_interface_config()
+                network.create_vlan_config()
+                network.create_bond_config()
+            assert file_handle.write.call_args_list == [
+                # eth0
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                # eth1
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                # vlan interface bond0.10
+                call(
+                    'BOOTPROTO=static\n'
+                    'DEVICE=bond0.10\n'
+                    'ETHERDEVICE=bond0\n'
+                    'IPADDR=10.250.10.51\n'
+                    'NETMASK=255.255.255.0\n'
+                    'ONBOOT=yes\n'
+                    'STARTMODE=auto\n'
+                    'VLAN=yes\n'
+                    'VLAN_ID=10\n'
+                ),
+                call('MTU=1500\n'),
+                # bond0
+                call(
+                    'BOOTPROTO=none\n'
+                    'DEVICE=bond0\n'
+                    'ONBOOT=yes\n'
+                    'STARTMODE=auto\n'
+                    'BONDING_MASTER=yes\n'
+                ),
+                call('MTU=9000\n'),
+                call('BONDING_MODULE_OPTS="opt=value"\n'),
+                call('BONDING_SLAVE0=eth0\n'),
+                call('BONDING_SLAVE1=eth1\n')
+            ]
+            assert mock_open.call_args_list == [
+                call('/etc/sysconfig/network/ifcfg-eth0', 'w'),
+                call('/etc/sysconfig/network/ifcfg-eth1', 'w'),
+                call('/etc/sysconfig/network/ifcfg-bond0.10', 'w'),
+                call('/etc/sysconfig/network/ifcfg-bond0', 'w')
+            ]

--- a/test/unit/units/network_test.py
+++ b/test/unit/units/network_test.py
@@ -27,6 +27,7 @@ class TestNetwork(object):
         status.set_success.assert_called_once_with()
         li_network.create_interface_config.assert_called_once_with()
         li_network.create_vlan_config.assert_called_once_with()
+        li_network.create_bond_config.assert_called_once_with()
         li_network.create_default_route_config.assert_called_once_with()
         mock_AzureHostedNetworkSetup.side_effect = Exception
         with raises(AzureHostedException):


### PR DESCRIPTION
Allow to setup bonding slaves on top of vlan interfaces
or direct bonding structure. Because bonding slave interfaces
comes with no ip/netmask setup the schema has to be changed
to allow interface list elements without ip and subnet_mask
fields which were required elements before.
This Fixes #114