### PR TITLE
Fix network service

### DIFF
--- a/azure_li_services/network.py
+++ b/azure_li_services/network.py
@@ -106,13 +106,10 @@ class AzureHostedNetworkSetup(object):
         )
         setup = dedent('''
             BOOTPROTO=static
-            DEVICE={interface}.{vlan}
             ETHERDEVICE={interface}
             IPADDR={ip}
             NETMASK={netmask}
-            ONBOOT=yes
             STARTMODE=auto
-            VLAN=yes
             VLAN_ID={vlan}
         ''').lstrip()
         with open(vlan_file, 'w') as ifcfg_vlan:
@@ -140,8 +137,6 @@ class AzureHostedNetworkSetup(object):
         )
         setup = dedent('''
             BOOTPROTO=none
-            DEVICE={interface}
-            ONBOOT=yes
             STARTMODE=auto
             BONDING_MASTER=yes
         ''').lstrip()

--- a/azure_li_services/network.py
+++ b/azure_li_services/network.py
@@ -101,8 +101,8 @@ class AzureHostedNetworkSetup(object):
         """
         if 'vlan' not in self.network:
             return
-        vlan_file = '/etc/sysconfig/network/ifcfg-{0}.{1}'.format(
-            self.network['interface'], self.network['vlan']
+        vlan_file = '/etc/sysconfig/network/ifcfg-vlan{0}'.format(
+            self.network['vlan']
         )
         setup = dedent('''
             BOOTPROTO=static

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -63,7 +63,7 @@ class TestAzureHostedNetworkSetup(object):
             network.create_vlan_config()
             file_handle = mock_open.return_value.__enter__.return_value
             mock_open.assert_called_once_with(
-                '/etc/sysconfig/network/ifcfg-eth0.10', 'w'
+                '/etc/sysconfig/network/ifcfg-vlan10', 'w'
             )
             assert file_handle.write.call_args_list == [
                 call(
@@ -130,9 +130,15 @@ class TestAzureHostedNetworkSetup(object):
                 network.create_bond_config()
             assert file_handle.write.call_args_list == [
                 # eth0
-                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                call(
+                    'BOOTPROTO=static\n'
+                    'STARTMODE=auto\n'
+                ),
                 # eth1
-                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                call(
+                    'BOOTPROTO=static\n'
+                    'STARTMODE=auto\n'
+                ),
                 # vlan interface bond0.10
                 call(
                     'BOOTPROTO=static\n'
@@ -157,6 +163,6 @@ class TestAzureHostedNetworkSetup(object):
             assert mock_open.call_args_list == [
                 call('/etc/sysconfig/network/ifcfg-eth0', 'w'),
                 call('/etc/sysconfig/network/ifcfg-eth1', 'w'),
-                call('/etc/sysconfig/network/ifcfg-bond0.10', 'w'),
+                call('/etc/sysconfig/network/ifcfg-vlan10', 'w'),
                 call('/etc/sysconfig/network/ifcfg-bond0', 'w')
             ]

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -68,13 +68,10 @@ class TestAzureHostedNetworkSetup(object):
             assert file_handle.write.call_args_list == [
                 call(
                     'BOOTPROTO=static\n'
-                    'DEVICE=eth0.10\n'
                     'ETHERDEVICE=eth0\n'
                     'IPADDR=10.250.10.51\n'
                     'NETMASK=255.255.255.0\n'
-                    'ONBOOT=yes\n'
                     'STARTMODE=auto\n'
-                    'VLAN=yes\n'
                     'VLAN_ID=10\n'
                 ),
                 call('MTU=1500\n')
@@ -107,8 +104,6 @@ class TestAzureHostedNetworkSetup(object):
                 # bond0
                 call(
                     'BOOTPROTO=none\n'
-                    'DEVICE=bond0\n'
-                    'ONBOOT=yes\n'
                     'STARTMODE=auto\n'
                     'BONDING_MASTER=yes\n'
                 ),
@@ -141,21 +136,16 @@ class TestAzureHostedNetworkSetup(object):
                 # vlan interface bond0.10
                 call(
                     'BOOTPROTO=static\n'
-                    'DEVICE=bond0.10\n'
                     'ETHERDEVICE=bond0\n'
                     'IPADDR=10.250.10.51\n'
                     'NETMASK=255.255.255.0\n'
-                    'ONBOOT=yes\n'
                     'STARTMODE=auto\n'
-                    'VLAN=yes\n'
                     'VLAN_ID=10\n'
                 ),
                 call('MTU=1500\n'),
                 # bond0
                 call(
                     'BOOTPROTO=none\n'
-                    'DEVICE=bond0\n'
-                    'ONBOOT=yes\n'
                     'STARTMODE=auto\n'
                     'BONDING_MASTER=yes\n'
                 ),


### PR DESCRIPTION
This patch is two fold, please review based on commits:

__Fixed network service vlan setup__
    
The vlan setup used the interface name in its ifcfg config file in the following format: ifcfg-<interface>.<vlan_id> However if the interface name is based on the MAC address that leads to a name which is longer than the fixed defined value from ```/usr/include/linux/if.h```: ```#define IFNAMSIZ 16``` and will make the network setup to fail. Therefore this patch changes the config file for the vlan setup to follow the format: ifcfg-vlan<vlan_id> which avoids that size limit. This Fixes #115

__Cleanup network service__
    
Delete unused elements from ifcfg configuration on suse systems
    
* ONBOOT, obsolete if STARTMODE is used
* VLAN, obsolete ETHERDEVICE gives the vlan type
* DEVICE, obsolete and invalid use of self reference. suse
   only uses this in the context of PPP(oE) interfaces which
   are not of interest in the scope of Azure LI/VLI