### PR TITLE
Add support for iSCSI SBD device setup

### DIFF
--- a/azure_li_services/exceptions.py
+++ b/azure_li_services/exceptions.py
@@ -101,3 +101,10 @@ class AzureHostedStorageMountException(AzureHostedException):
     Exception raised if any of the required data to create a valid
     fstab entry to mount some storage device is missing
     """
+
+
+class AzureHostedCommandOutputException(AzureHostedException):
+    """
+    Exception raised if the output of a command did not match
+    the expected format or content
+    """

--- a/azure_li_services/runtime_config.py
+++ b/azure_li_services/runtime_config.py
@@ -47,6 +47,10 @@ class RuntimeConfig(object):
           min_cores: number_of_cores
           min_memory: main_memory_value_with_unit
 
+        stonith:
+          initiatorname: name
+          ip: 192.168.100.20
+
         networking:
           -
             interface: eth0
@@ -157,3 +161,7 @@ class RuntimeConfig(object):
     def get_storage_config(self):
         if self.config_data:
             return self.config_data.get('storage')
+
+    def get_stonith_config(self):
+        if self.config_data:
+            return self.config_data.get('stonith')

--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -35,6 +35,22 @@ schema = {
             }
         }
     },
+    'stonith': {
+        'required': False,
+        'type': 'dict',
+        'schema': {
+            'initiatorname': {
+                'required': True,
+                'nullable': False,
+                'type': 'string'
+            },
+            'ip': {
+                'required': True,
+                'nullable': False,
+                'type': 'string'
+            }
+        }
+    },
     'machine_constraints': {
         'required': False,
         'type': 'dict',

--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -247,6 +247,9 @@ def set_stonith_service(config):
         Command.run(
             ['sbd', '-d', target_device, 'dump']
         )
+        _write_file(
+            '/etc/sysconfig/sbd', 'SBD_DEVICE="{0}"'.format(target_device)
+        )
     else:
         raise AzureHostedCommandOutputException(
             'Stonith: Unexpected iSCSI discovery information: {0}'.format(

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ formats=gztar
 
 [tool:pytest]
 norecursedirs = .git build .tox/ .tmp/
-addopts = --ignore=.tmp/ --ignore=.git/ --ignore=.tox/
+addopts = --ignore=.tmp/ --ignore=.git/ --ignore=.tox/ -p no:warnings
 testpaths = test/unit/
 
 [flake8]

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -12,6 +12,10 @@ machine_constraints:
   min_cores: 32
   min_memory: "20tb"
 
+stonith:
+  initiatorname: "t090xyzzysid4"
+  ip: "192.168.100.20"
+
 networking:
   -
     interface: eth0

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -122,3 +122,8 @@ class TestRuntimeConfig(object):
         assert self.runtime_config.get_crash_dump_config() == {
             'activate': True, 'crash_kernel_low': 80, 'crash_kernel_high': 160
         }
+
+    def test_get_stonith_config(self):
+        assert self.runtime_config.get_stonith_config() == {
+            'initiatorname': 't090xyzzysid4', 'ip': '192.168.100.20'
+        }

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -11,7 +11,10 @@ from azure_li_services.units.system_setup import main
 
 import azure_li_services.units.system_setup as system_setup
 
-from azure_li_services.exceptions import AzureHostedException
+from azure_li_services.exceptions import (
+    AzureHostedException,
+    AzureHostedCommandOutputException
+)
 
 
 class TestSystemSetup(object):
@@ -19,6 +22,7 @@ class TestSystemSetup(object):
         self.config = RuntimeConfig('../data/config.yaml')
 
     @patch.object(system_setup, 'set_hostname')
+    @patch.object(system_setup, 'set_stonith_service')
     @patch.object(system_setup, 'set_kdump_service')
     @patch.object(system_setup, 'set_kernel_samepage_merging_mode')
     @patch.object(system_setup, 'set_energy_performance_settings')
@@ -33,13 +37,17 @@ class TestSystemSetup(object):
         mock_set_saptune_service,
         mock_set_energy_performance_settings,
         mock_set_kernel_samepage_merging_mode,
-        mock_set_kdump_service, mock_set_hostname
+        mock_set_kdump_service, mock_set_stonith_service,
+        mock_set_hostname
     ):
         status = Mock()
         mock_StatusReport.return_value = status
         mock_RuntimConfig.return_value = self.config
         main()
         mock_set_hostname.assert_called_once_with('azure')
+        mock_set_stonith_service.assert_called_once_with(
+            {'initiatorname': 't090xyzzysid4', 'ip': '192.168.100.20'}
+        )
         mock_set_kdump_service.assert_called_once_with(
             {
                 'activate': True,
@@ -64,6 +72,11 @@ class TestSystemSetup(object):
             main()
 
         mock_set_hostname.reset_mock()
+        mock_set_stonith_service.side_effect = Exception
+        with raises(AzureHostedException):
+            main()
+
+        mock_set_stonith_service.reset_mock()
         mock_set_kdump_service.side_effect = Exception
         with raises(AzureHostedException):
             main()
@@ -203,4 +216,104 @@ class TestSystemSetup(object):
             mock_open.assert_called_once_with('/boot/efi/startup.nsh', 'w')
             assert file_handle.write.call_args_list == [
                 call('fs0:\\efi\\sles_sap\\grubx64.efi\n')
+            ]
+
+    @patch('azure_li_services.command.Command.run')
+    def test_set_stonith_service_discovery_failed(self, mock_Command_run):
+        command = Mock
+        command.output = 'artificial'
+        mock_Command_run.return_value = command
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.read.return_value = ''
+            with raises(AzureHostedCommandOutputException):
+                system_setup.set_stonith_service(
+                    {'initiatorname': 't090xyzzysid4', 'ip': '10.20.253.31'}
+                )
+
+    @patch('azure_li_services.command.Command.run')
+    def test_set_stonith_service(self, mock_Command_run):
+        command = Mock
+        command.output = os.linesep.join(
+            [
+                '10.20.253.31:3260,1054 iqn.1992-08.com.netapp:sn.'
+                '562892c1030b11e9b8ec00a098d274e4:vs.6',
+                '10.20.253.42:3260,1057 iqn.1992-08.com.netapp:sn.'
+                '562892c1030b11e9b8ec00a098d274e4:vs.6'
+            ]
+        )
+        mock_Command_run.return_value = command
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open_initiator = MagicMock(spec=io.IOBase)
+            mock_open_iscsi = MagicMock(spec=io.IOBase)
+
+            def open_file(filename, mode):
+                if filename == '/etc/iscsi/initiatorname.iscsi':
+                    return mock_open_initiator.return_value
+                elif filename == '/etc/iscsi/iscsid.conf':
+                    return mock_open_iscsi.return_value
+
+            mock_open.side_effect = open_file
+
+            file_handle_initiator = \
+                mock_open_initiator.return_value.__enter__.return_value
+            file_handle_iscsi = \
+                mock_open_iscsi.return_value.__enter__.return_value
+
+            file_handle_initiator.read.return_value = 'InitiatorName=name'
+            file_handle_iscsi.read.return_value = dedent('''
+                node.session.timeo.replacement_timeout = 120
+                node.startup = manual
+            ''')
+
+            system_setup.set_stonith_service(
+                {'initiatorname': 't090xyzzysid4', 'ip': '10.20.253.31'}
+            )
+            assert mock_open.call_args_list == [
+                call('/etc/iscsi/initiatorname.iscsi', 'r'),
+                call('/etc/iscsi/initiatorname.iscsi', 'w'),
+                call('/etc/iscsi/iscsid.conf', 'r'),
+                call('/etc/iscsi/iscsid.conf', 'w')
+            ]
+            assert file_handle_initiator.write.call_args_list == [
+                call('InitiatorName=iqn.1996-04.de.suse:01:t090xyzzysid4')
+            ]
+            assert file_handle_iscsi.write.call_args_list == [
+                call(dedent('''
+                    node.session.timeo.replacement_timeout = 5
+                    node.startup = automatic
+                '''))
+            ]
+            assert mock_Command_run.call_args_list == [
+                call(
+                    [
+                        'iscsiadm', '-m', 'discovery', '-t',
+                        'st', '-p', '10.20.253.31:3260'
+                    ]
+                ),
+                call(
+                    ['iscsiadm', '-m', 'node', '-l']
+                ),
+                call(
+                    ['rescan-scsi-bus.sh']
+                ),
+                call(
+                    [
+                        'sbd', '-d',
+                        '/dev/disk/by-path/ip-10.20.253.31:3260-iscsi-iqn.'
+                        '1992-08.com.netapp:sn.'
+                        '562892c1030b11e9b8ec00a098d274e4:vs.6-lun-0',
+                        'create'
+                    ]
+                ),
+                call(
+                    [
+                        'sbd', '-d',
+                        '/dev/disk/by-path/ip-10.20.253.31:3260-iscsi-iqn.'
+                        '1992-08.com.netapp:sn.'
+                        '562892c1030b11e9b8ec00a098d274e4:vs.6-lun-0',
+                        'dump'
+                    ]
+                )
             ]


### PR DESCRIPTION
In a new an optional stonith section the configuration for
the iSCSI initiator and ip address can be setup. Once present
the process to setup the iSCSI initiator as well as the
device discovery is started. This Fixes bsc#1125373 and
bsc#1125372 and Fixes #119