### PR TITLE
Fixup system-setup service dependencies

### DIFF
--- a/systemd/azure-li-system-setup.service
+++ b/systemd/azure-li-system-setup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=System Setup of Azure Li/VLi machine
 ConditionPathExists=/.azure-li-system-setup.trigger
-After=azure-li-config-lookup.service azure-li-install.service systemd-hostnamed.service
+After=azure-li-config-lookup.service azure-li-install.service systemd-hostnamed.service azure-li-network.service network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The setup of the stonith SBD device requires the network
to be up beforehand because the target is an iSCSI endpoint.
This Fixes #119