### PR TITLE
Umount LUN only on cleanup

### DIFF
--- a/azure_li_services/units/call.py
+++ b/azure_li_services/units/call.py
@@ -34,15 +34,12 @@ def main():
 
     if call_script:
         call_source = Defaults.mount_config_source()
-        try:
-            Command.run(
-                [
-                    'bash', '-c', '{0}/{1}'.format(
-                        call_source.location, call_script
-                    )
-                ]
-            )
-        finally:
-            Defaults.umount_config_source(call_source)
+        Command.run(
+            [
+                'bash', '-c', '{0}/{1}'.format(
+                    call_source.location, call_script
+                )
+            ]
+        )
 
     status.set_success()

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -156,25 +156,22 @@ def setup_ssh_authorization(user):
                 os.chown(ssh_auth_file, uid, gid)
         if 'ssh-private-key' in user:
             ssh_key_source = Defaults.mount_config_source()
-            try:
-                private_key_file = user['ssh-private-key']
-                Command.run(
-                    [
-                        'cp', os.sep.join(
-                            [ssh_key_source.location, private_key_file]
-                        ), ssh_auth_dir
-                    ]
+            private_key_file = user['ssh-private-key']
+            Command.run(
+                [
+                    'cp', os.sep.join(
+                        [ssh_key_source.location, private_key_file]
+                    ), ssh_auth_dir
+                ]
+            )
+            ssh_key_file = os.path.normpath(
+                os.sep.join(
+                    [ssh_auth_dir, os.path.basename(private_key_file)]
                 )
-                ssh_key_file = os.path.normpath(
-                    os.sep.join(
-                        [ssh_auth_dir, os.path.basename(private_key_file)]
-                    )
-                )
-                os.chmod(ssh_key_file, 0o600)
-                if user['username'] != 'root':
-                    os.chown(ssh_key_file, uid, gid)
-            finally:
-                Defaults.umount_config_source(ssh_key_source)
+            )
+            os.chmod(ssh_key_file, 0o600)
+            if user['username'] != 'root':
+                os.chown(ssh_key_file, uid, gid)
 
 
 def setup_sudo_authorization(user):

--- a/test/unit/units/call_test.py
+++ b/test/unit/units/call_test.py
@@ -26,11 +26,5 @@ class TestCall(object):
                         mock_mount_config_source.return_value.location
                     )
                 ]
-            ),
-            call(
-                [
-                    'umount', '--lazy',
-                    mock_mount_config_source.return_value.location
-                ], raise_on_error=False
             )
         ]

--- a/test/unit/units/install_test.py
+++ b/test/unit/units/install_test.py
@@ -117,11 +117,5 @@ class TestInstall(object):
                     '--auto-agree-with-licenses',
                     'foo', 'package_a', 'package_b'
                 ]
-            ),
-            call(
-                [
-                    'umount', '--lazy',
-                    mock_mount_config_source.return_value.location
-                ], raise_on_error=False
             )
         ]

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -107,9 +107,6 @@ class TestUser(object):
                         'cp', 'config_mount/path/to/private/key/id_dsa',
                         '/home/hanauser/.ssh/'
                     ]
-                ),
-                call(
-                    ['umount', '--lazy', 'config_mount'], raise_on_error=False
                 )
             ]
             assert mock_chmod.call_args_list == [


### PR DESCRIPTION
If one service(A) needs the LUN and another service(B) that needs
the LUN too runs in parallel a potential race condition exists
in a way the service A could have umounted the LUN exactly at
a time service B accesses it. Thus this patch changes the
services such that only the last service, the cleanup service
umounts the LUN. This Fixes #137