### PR TITLE
Activate SAP Hana profile via tuned-adm

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -135,6 +135,14 @@ def set_saptune_service():
     Command.run(
         ['saptune', 'solution', 'apply', 'HANA']
     )
+    if os.path.exists('/usr/lib/tuned/sap-hana'):
+        Command.run(
+            ['tuned-adm', 'profile', 'sap-hana']
+        )
+    else:
+        Command.run(
+            ['tuned-adm', 'profile', 'sapconf']
+        )
 
 
 def set_reboot_intervention():

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -199,13 +199,26 @@ class TestSystemSetup(object):
             status.set_reboot_required.assert_called_once_with()
 
     @patch('azure_li_services.command.Command.run')
-    def test_set_saptune_service(self, mock_Command_run):
+    @patch('os.path.exists')
+    def test_set_saptune_service(self, mock_os_path_exists, mock_Command_run):
+        mock_os_path_exists.return_value = True
         system_setup.set_saptune_service()
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'enable', 'tuned']),
             call(['systemctl', 'start', 'tuned']),
             call(['saptune', 'daemon', 'start']),
             call(['saptune', 'solution', 'apply', 'HANA']),
+            call(['tuned-adm', 'profile', 'sap-hana'])
+        ]
+        mock_os_path_exists.return_value = False
+        mock_Command_run.reset_mock()
+        system_setup.set_saptune_service()
+        assert mock_Command_run.call_args_list == [
+            call(['systemctl', 'enable', 'tuned']),
+            call(['systemctl', 'start', 'tuned']),
+            call(['saptune', 'daemon', 'start']),
+            call(['saptune', 'solution', 'apply', 'HANA']),
+            call(['tuned-adm', 'profile', 'sapconf'])
         ]
 
     @patch('os.path.exists')


### PR DESCRIPTION
Check for the presence of the sap-hana profile and switch
to sapconf if not found. Activate the selected profile via
the tuned-adm control command. This Fixes #142