### PR TITLE
Mount LUN in sync mode

### DIFF
--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -109,7 +109,11 @@ class Defaults(object):
             return azure_config
 
         lun_result = Command.run(
-            ['mount', '--label', azure_config.label, azure_config.location],
+            [
+                'mount', '-o', 'sync',
+                '--label', azure_config.label,
+                azure_config.location
+            ],
             raise_on_error=False
         )
         if lun_result.returncode != 0:

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -44,7 +44,7 @@ class TestDefaults(object):
                 ['mountpoint', '/mnt'], raise_on_error=False
             ),
             call(
-                ['mount', '--label', 'azconfig', '/mnt'],
+                ['mount', '-o', 'sync', '--label', 'azconfig', '/mnt'],
                 raise_on_error=False
             )
         ]
@@ -61,7 +61,7 @@ class TestDefaults(object):
                 ['mountpoint', '/mnt'], raise_on_error=False
             ),
             call(
-                ['mount', '--label', 'azconfig', '/mnt'],
+                ['mount', '-o', 'sync', '--label', 'azconfig', '/mnt'],
                 raise_on_error=False
             ),
             call(


### PR DESCRIPTION
Per request from Microsoft the location that holds the
config file and is also used for the status flag and
log should be mounted with the sync option.
This Fixes #144