### PR TITLE
Fix service order on startup of saptune daemon

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -129,12 +129,6 @@ def set_saptune_service():
     Command.run(
         ['systemctl', 'start', 'tuned']
     )
-    Command.run(
-        ['saptune', 'daemon', 'start']
-    )
-    Command.run(
-        ['saptune', 'solution', 'apply', 'HANA']
-    )
     if os.path.exists('/usr/lib/tuned/sap-hana'):
         Command.run(
             ['tuned-adm', 'profile', 'sap-hana']
@@ -143,6 +137,12 @@ def set_saptune_service():
         Command.run(
             ['tuned-adm', 'profile', 'sapconf']
         )
+    Command.run(
+        ['saptune', 'daemon', 'start']
+    )
+    Command.run(
+        ['saptune', 'solution', 'apply', 'HANA']
+    )
 
 
 def set_reboot_intervention():

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -206,9 +206,9 @@ class TestSystemSetup(object):
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'enable', 'tuned']),
             call(['systemctl', 'start', 'tuned']),
+            call(['tuned-adm', 'profile', 'sap-hana']),
             call(['saptune', 'daemon', 'start']),
-            call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['tuned-adm', 'profile', 'sap-hana'])
+            call(['saptune', 'solution', 'apply', 'HANA'])
         ]
         mock_os_path_exists.return_value = False
         mock_Command_run.reset_mock()
@@ -216,9 +216,9 @@ class TestSystemSetup(object):
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'enable', 'tuned']),
             call(['systemctl', 'start', 'tuned']),
+            call(['tuned-adm', 'profile', 'sapconf']),
             call(['saptune', 'daemon', 'start']),
-            call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['tuned-adm', 'profile', 'sapconf'])
+            call(['saptune', 'solution', 'apply', 'HANA'])
         ]
 
     @patch('os.path.exists')


### PR DESCRIPTION
The tuned profile must be applied prior to the start of
the saptune daemon. This Fixes #149