### PR TITLE
Fix saptune service setup

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -129,6 +129,12 @@ def set_saptune_service():
     Command.run(
         ['systemctl', 'start', 'tuned']
     )
+    Command.run(
+        ['saptune', 'daemon', 'start']
+    )
+    Command.run(
+        ['saptune', 'solution', 'apply', 'HANA']
+    )
     if os.path.exists('/usr/lib/tuned/sap-hana'):
         Command.run(
             ['tuned-adm', 'profile', 'sap-hana']
@@ -137,12 +143,6 @@ def set_saptune_service():
         Command.run(
             ['tuned-adm', 'profile', 'sapconf']
         )
-    Command.run(
-        ['saptune', 'daemon', 'start']
-    )
-    Command.run(
-        ['saptune', 'solution', 'apply', 'HANA']
-    )
 
 
 def set_reboot_intervention():

--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -143,6 +143,9 @@ def set_saptune_service():
         Command.run(
             ['tuned-adm', 'profile', 'sapconf']
         )
+    Command.run(
+        ['saptune', 'daemon', 'start']
+    )
 
 
 def set_reboot_intervention():

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -208,7 +208,8 @@ class TestSystemSetup(object):
             call(['systemctl', 'start', 'tuned']),
             call(['saptune', 'daemon', 'start']),
             call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['tuned-adm', 'profile', 'sap-hana'])
+            call(['tuned-adm', 'profile', 'sap-hana']),
+            call(['saptune', 'daemon', 'start'])
         ]
         mock_os_path_exists.return_value = False
         mock_Command_run.reset_mock()
@@ -218,7 +219,8 @@ class TestSystemSetup(object):
             call(['systemctl', 'start', 'tuned']),
             call(['saptune', 'daemon', 'start']),
             call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['tuned-adm', 'profile', 'sapconf'])
+            call(['tuned-adm', 'profile', 'sapconf']),
+            call(['saptune', 'daemon', 'start'])
         ]
 
     @patch('os.path.exists')

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -206,9 +206,9 @@ class TestSystemSetup(object):
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'enable', 'tuned']),
             call(['systemctl', 'start', 'tuned']),
-            call(['tuned-adm', 'profile', 'sap-hana']),
             call(['saptune', 'daemon', 'start']),
-            call(['saptune', 'solution', 'apply', 'HANA'])
+            call(['saptune', 'solution', 'apply', 'HANA']),
+            call(['tuned-adm', 'profile', 'sap-hana'])
         ]
         mock_os_path_exists.return_value = False
         mock_Command_run.reset_mock()
@@ -216,9 +216,9 @@ class TestSystemSetup(object):
         assert mock_Command_run.call_args_list == [
             call(['systemctl', 'enable', 'tuned']),
             call(['systemctl', 'start', 'tuned']),
-            call(['tuned-adm', 'profile', 'sapconf']),
             call(['saptune', 'daemon', 'start']),
-            call(['saptune', 'solution', 'apply', 'HANA'])
+            call(['saptune', 'solution', 'apply', 'HANA']),
+            call(['tuned-adm', 'profile', 'sapconf'])
         ]
 
     @patch('os.path.exists')


### PR DESCRIPTION
This patch is two fold

* Revert fix for service order of saptune daemon
  It has turned out that the simple change in order did
  not solve the problem. In fact the daemon needs to be
  restarted on profile setup

* Start saptune daemon after applying profile
  For some reason the saptune daemon needs to restart if a
  profile has been set through the tuned-adm profile command.
  This Fixes #149
