### PR TITLE
Load yaml in safe mode

### DIFF
--- a/azure_li_services/runtime_config.py
+++ b/azure_li_services/runtime_config.py
@@ -100,7 +100,7 @@ class RuntimeConfig(object):
         if os.path.exists(config_file):
             with open(config_file, 'r') as config:
                 try:
-                    self.config_data = yaml.load(config)
+                    self.config_data = yaml.safe_load(config)
                 except Exception as e:
                     raise AzureHostedConfigDataException(
                         'Loading yaml format raises: {0}: {1}'.format(

--- a/azure_li_services/status_report.py
+++ b/azure_li_services/status_report.py
@@ -70,7 +70,7 @@ class StatusReport(object):
     def load(self):
         if os.path.exists(self.status_file):
             with open(self.status_file, 'r') as report:
-                self.status = yaml.load(report)
+                self.status = yaml.safe_load(report)
 
     def get_state(self):
         return self.status[self.service_name]['success']

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -10,7 +10,7 @@ class TestRuntimeConfig(object):
     def setup(self):
         self.runtime_config = RuntimeConfig('../data/config.yaml')
 
-    @patch('yaml.load')
+    @patch('yaml.safe_load')
     def test_init_raises_on_invalid_format(self, mock_yaml_load):
         mock_yaml_load.side_effect = Exception
         with raises(AzureHostedConfigDataException):


### PR DESCRIPTION
The default yaml loader is unsafe, thus we should switch
to the safe_load method. For details see: https://msg.pyyaml.org/load