### PR TITLE
Fixed network setup for bonding on vlan

### DIFF
--- a/azure_li_services/network.py
+++ b/azure_li_services/network.py
@@ -144,15 +144,17 @@ class AzureHostedNetworkSetup(object):
                 setup.format(interface=self.network['interface'])
             )
             if 'vlan' not in self.network:
-                # bond takes IP setup if no vlan is requested
-                ifcfg_bond.write(
-                    'IPADDR={0}{1}'.format(self.network['ip'], os.linesep)
-                )
-                ifcfg_bond.write(
-                    'NETMASK={0}{1}'.format(
-                        self.network['subnet_mask'], os.linesep
+                # bond takes IP setup if present and no vlan is requested
+                if 'ip' in self.network:
+                    ifcfg_bond.write(
+                        'IPADDR={0}{1}'.format(self.network['ip'], os.linesep)
                     )
-                )
+                if 'subnet_mask' in self.network:
+                    ifcfg_bond.write(
+                        'NETMASK={0}{1}'.format(
+                            self.network['subnet_mask'], os.linesep
+                        )
+                    )
             if 'mtu' in self.network:
                 ifcfg_bond.write(
                     'MTU={0}{1}'.format(self.network['mtu'], os.linesep)

--- a/test/data/config-net-bond-vlan.yaml
+++ b/test/data/config-net-bond-vlan.yaml
@@ -1,0 +1,70 @@
+version: "20180614"
+instance_type: LargeInstance
+sku: "SR92"
+
+networking:
+  -
+    interface: eth3
+
+  -
+    interface: eth4
+
+  -
+    interface: eth5
+
+  -
+    interface: eth6
+
+  -
+    interface: bond0
+    bonding_slaves:
+      - eth3
+      - eth6
+    bonding_options:
+      - mode=active-backup
+      - miimon=100
+
+  -
+    interface: bond1
+    bonding_slaves:
+      - eth4
+      - eth5
+    bonding_options:
+      - mode=active-backup
+      - miimon=100
+
+  -
+    interface: bond0
+    vlan: 250
+    ip: 10.60.0.35
+    subnet_mask: 255.255.255.0
+    vlan_mtu: 9000
+    gateway: 10.60.0.1
+
+  -
+    interface: bond0
+    vlan: 251
+    ip: 10.20.251.150
+    subnet_mask: 255.255.255.0
+    vlan_mtu: 9000
+
+  -
+    interface: bond0
+    vlan: 253
+    ip: 10.20.253.150
+    subnet_mask: 255.255.255.0
+    vlan_mtu: 9000
+
+  -
+    interface: bond1
+    vlan: 252
+    ip: 10.20.252.150
+    subnet_mask: 255.255.255.0
+    vlan_mtu: 9000
+
+
+credentials:
+  -
+    username: root
+    shadow_hash: "sha-512-cipher"
+    ssh-key: "ssh-rsa foo"

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -12,11 +12,13 @@ class TestAzureHostedNetworkSetup(object):
         config_nic = RuntimeConfig('../data/config-net.yaml')
         config_vlan = RuntimeConfig('../data/config-net-vlan.yaml')
         config_bond = RuntimeConfig('../data/config-net-bond.yaml')
+        config_bond_vlan = RuntimeConfig('../data/config-net-bond-vlan.yaml')
         config_vlan_bond = RuntimeConfig('../data/config-net-vlan-bond.yaml')
 
         self.network_config = config_nic.get_network_config()
         self.network_config_vlan = config_vlan.get_network_config()
         self.network_config_bond = config_bond.get_network_config()
+        self.network_config_bond_vlan = config_bond_vlan.get_network_config()
         self.network_config_vlan_bond = config_vlan_bond.get_network_config()
 
     def test_create_default_route_config(self):
@@ -117,6 +119,92 @@ class TestAzureHostedNetworkSetup(object):
                 call('/etc/sysconfig/network/ifcfg-eth0', 'w'),
                 call('/etc/sysconfig/network/ifcfg-eth1', 'w'),
                 call('/etc/sysconfig/network/ifcfg-bond0', 'w')
+            ]
+
+    def test_create_bond_vlan_config(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            for network_config in self.network_config_bond_vlan:
+                network = AzureHostedNetworkSetup(network_config)
+                network.create_interface_config()
+                network.create_vlan_config()
+                network.create_bond_config()
+                network.create_default_route_config()
+            assert mock_open.call_args_list == [
+                call('/etc/sysconfig/network/ifcfg-eth3', 'w'),
+                call('/etc/sysconfig/network/ifcfg-eth4', 'w'),
+                call('/etc/sysconfig/network/ifcfg-eth5', 'w'),
+                call('/etc/sysconfig/network/ifcfg-eth6', 'w'),
+                call('/etc/sysconfig/network/ifcfg-bond0', 'w'),
+                call('/etc/sysconfig/network/ifcfg-bond1', 'w'),
+                call('/etc/sysconfig/network/ifcfg-vlan250', 'w'),
+                call('/etc/sysconfig/network/ifroute-vlan250', 'w'),
+                call('/etc/sysconfig/network/ifcfg-vlan251', 'w'),
+                call('/etc/sysconfig/network/ifcfg-vlan253', 'w'),
+                call('/etc/sysconfig/network/ifcfg-vlan252', 'w')
+            ]
+            assert file_handle.write.call_args_list == [
+                # eth3-6
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                call('BOOTPROTO=static\nSTARTMODE=auto\n'),
+                # bond0-1
+                call(
+                    'BOOTPROTO=none\n'
+                    'STARTMODE=auto\n'
+                    'BONDING_MASTER=yes\n'
+                ),
+                call('BONDING_MODULE_OPTS="mode=active-backup miimon=100"\n'),
+                call('BONDING_SLAVE0=eth3\n'),
+                call('BONDING_SLAVE1=eth6\n'),
+                call(
+                    'BOOTPROTO=none\n'
+                    'STARTMODE=auto\n'
+                    'BONDING_MASTER=yes\n'
+                ),
+                call('BONDING_MODULE_OPTS="mode=active-backup miimon=100"\n'),
+                call('BONDING_SLAVE0=eth4\n'),
+                call('BONDING_SLAVE1=eth5\n'),
+                # vlan250-253
+                call(
+                    'BOOTPROTO=static\n'
+                    'ETHERDEVICE=bond0\n'
+                    'IPADDR=10.60.0.35\n'
+                    'NETMASK=255.255.255.0\n'
+                    'STARTMODE=auto\n'
+                    'VLAN_ID=250\n'
+                ),
+                call('MTU=9000\n'),
+                call('default 10.60.0.1 - vlan250\n'),
+                call(
+                    'BOOTPROTO=static\n'
+                    'ETHERDEVICE=bond0\n'
+                    'IPADDR=10.20.251.150\n'
+                    'NETMASK=255.255.255.0\n'
+                    'STARTMODE=auto\n'
+                    'VLAN_ID=251\n'
+                ),
+                call('MTU=9000\n'),
+                call(
+                    'BOOTPROTO=static\n'
+                    'ETHERDEVICE=bond0\n'
+                    'IPADDR=10.20.253.150\n'
+                    'NETMASK=255.255.255.0\n'
+                    'STARTMODE=auto\n'
+                    'VLAN_ID=253\n'
+                ),
+                call('MTU=9000\n'),
+                call(
+                    'BOOTPROTO=static\n'
+                    'ETHERDEVICE=bond1\n'
+                    'IPADDR=10.20.252.150\n'
+                    'NETMASK=255.255.255.0\n'
+                    'STARTMODE=auto\n'
+                    'VLAN_ID=252\n'
+                ),
+                call('MTU=9000\n')
             ]
 
     def test_create_vlan_bond_config(self):


### PR DESCRIPTION
vlan network definitions that uses bonding etherdevices
were missing a switch to correctly assign the ip configuration
This Fixes #164