### PR TITLE
Extend storage service dependencies

### DIFF
--- a/systemd/azure-li-storage.service
+++ b/systemd/azure-li-storage.service
@@ -2,6 +2,7 @@
 Description=Setup of Azure Li/VLi Storage Mountpoints
 ConditionPathExists=/.azure-li-storage.trigger
 After=azure-li-config-lookup.service azure-li-network.service network.target
+Requires=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The storage service can be used for remote storage like NFS
storage to be attached to the machine. This requires the network
to be online. Having the network only configured is not enough
it must also be online. Thus the storage service unit is extended
to wait for the network-online.target