### PR TITLE
Added more logging to the process

### DIFF
--- a/azure_li_services/command.py
+++ b/azure_li_services/command.py
@@ -27,7 +27,7 @@ from .exceptions import (
     AzureHostedCommandNotFoundException
 )
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('Azure_LI_Services')
 
 
 class Command(object):
@@ -86,7 +86,7 @@ class Command(object):
             else:
                 raise AzureHostedCommandNotFoundException(message)
         try:
-            logging.info('Calling: {0}'.format(command))
+            logger.info('Calling: {0}'.format(command))
             process = subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,
@@ -156,7 +156,7 @@ class Command(object):
                 'Command "%s" not found in the environment' % command[0]
             )
         try:
-            logging.info('Calling: {0}'.format(command))
+            logger.info('Calling: {0}'.format(command))
             process = subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,

--- a/azure_li_services/defaults.py
+++ b/azure_li_services/defaults.py
@@ -33,16 +33,20 @@ class Defaults(object):
 
     Provides class methods for default values
     """
-    @classmethod
-    def get_config_file_name(self):
+    @staticmethod
+    def get_log_file():
+        return '/var/log/azure-li-services.log'
+
+    @staticmethod
+    def get_config_file_name():
         return '/etc/suse_firstboot_config.yaml'
 
-    @classmethod
-    def get_status_report_directory(self):
+    @staticmethod
+    def get_status_report_directory():
         return '/var/lib/azure_li_services'
 
-    @classmethod
-    def get_service_reports(self):
+    @staticmethod
+    def get_service_reports():
         from azure_li_services.status_report import StatusReport
         service_reports = []
         unit_to_service_map = {
@@ -74,8 +78,8 @@ class Defaults(object):
             service_reports.append(report)
         return service_reports
 
-    @classmethod
-    def get_config_file(self):
+    @staticmethod
+    def get_config_file():
         """
         Provides config file as stored locally
 
@@ -92,8 +96,8 @@ class Defaults(object):
                 'No Azure Li/VLi file found: {0}'.format(config_file)
             )
 
-    @classmethod
-    def mount_config_source(self):
+    @staticmethod
+    def mount_config_source():
         config_type = namedtuple(
             'config_type', ['name', 'location', 'label']
         )
@@ -130,16 +134,16 @@ class Defaults(object):
 
         return azure_config
 
-    @classmethod
-    def umount_config_source(self, azure_config):
+    @staticmethod
+    def umount_config_source(azure_config):
         Command.run(
             ['umount', '--lazy', azure_config.location], raise_on_error=False
         )
 
-    @classmethod
-    def get_stonith_needed_modules(self):
+    @staticmethod
+    def get_stonith_needed_modules():
         return ['softdog']
 
-    @classmethod
-    def get_extra_kernel_modules_file_name(self):
+    @staticmethod
+    def get_extra_kernel_modules_file_name():
         return '/etc/modules-load.d/azure-extra-modules.conf'

--- a/azure_li_services/logger.py
+++ b/azure_li_services/logger.py
@@ -15,33 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
+import logging
+
 # project
-from azure_li_services.logger import Logger
-from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
-from azure_li_services.command import Command
-from azure_li_services.status_report import StatusReport
 
 
-def main():
-    """
-    Azure Li/Vli script call
+class Logger:
+    @staticmethod
+    def setup():
+        logger = logging.getLogger('Azure_LI_Services')
+        logger.setLevel(logging.INFO)
 
-    Calls a custom script in the scope of an Azure Li/Vli instance
-    """
-    Logger.setup()
-    status = StatusReport('call')
-    config = RuntimeConfig(Defaults.get_config_file())
-    call_script = config.get_call_script()
+        log_file = logging.FileHandler(Defaults.get_log_file())
+        log_file.setLevel(logging.INFO)
 
-    if call_script:
-        call_source = Defaults.mount_config_source()
-        Command.run(
-            [
-                'bash', '-c', '{0}/{1}'.format(
-                    call_source.location, call_script
-                )
-            ]
-        )
+        log_stream = logging.StreamHandler()
+        log_stream.setLevel(logging.INFO)
 
-    status.set_success()
+        logger.addHandler(log_stream)
+        logger.addHandler(log_file)

--- a/azure_li_services/units/cleanup.py
+++ b/azure_li_services/units/cleanup.py
@@ -18,6 +18,7 @@
 import os
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.command import Command
 from azure_li_services.defaults import Defaults
 
@@ -29,6 +30,7 @@ def main():
     Uninstall azure-li-services package and its dependencies
     and check for potential reboot request
     """
+    Logger.setup()
     service_reports = Defaults.get_service_reports()
 
     reboot_system = False
@@ -108,4 +110,8 @@ def write_service_log(install_source):
     )
     Command.run(
         ['bash', '-c', bash_command], raise_on_error=False
+    )
+    Command.run(
+        ['cp', Defaults.get_log_file(), install_source.location],
+        raise_on_error=False
     )

--- a/azure_li_services/units/config_lookup.py
+++ b/azure_li_services/units/config_lookup.py
@@ -18,6 +18,7 @@
 import os
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.command import Command
 from azure_li_services.path import Path
 from azure_li_services.exceptions import AzureHostedConfigFileNotFoundException
@@ -33,6 +34,7 @@ def main():
     and make it locally available at the location described by
     Defaults.get_config_file_name()
     """
+    Logger.setup()
     status = StatusReport('config_lookup')
     azure_config = Defaults.mount_config_source()
 

--- a/azure_li_services/units/install.py
+++ b/azure_li_services/units/install.py
@@ -19,6 +19,7 @@ import os
 import glob
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
@@ -34,6 +35,7 @@ def main():
     Installs all packages configured in the scope of an Azure
     Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('install')
     config = RuntimeConfig(Defaults.get_config_file())
     packages_config = config.get_packages_config()

--- a/azure_li_services/units/machine_constraints.py
+++ b/azure_li_services/units/machine_constraints.py
@@ -20,6 +20,7 @@ import humanfriendly
 from psutil import virtual_memory
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.status_report import StatusReport
@@ -36,6 +37,7 @@ def main():
 
     Validation of machine requirements in the scope of an Azure Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('machine_constraints')
     config = RuntimeConfig(Defaults.get_config_file())
     machine_constraints = config.get_machine_constraints()

--- a/azure_li_services/units/network.py
+++ b/azure_li_services/units/network.py
@@ -16,6 +16,7 @@
 # along with azure-li-services.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.network import AzureHostedNetworkSetup
@@ -35,6 +36,7 @@ def main():
     Creates network configuration files to successfully start the
     network in the scope of an Azure Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('network')
     config = RuntimeConfig(Defaults.get_config_file())
     network_config = config.get_network_config()

--- a/azure_li_services/units/report.py
+++ b/azure_li_services/units/report.py
@@ -18,6 +18,7 @@
 import os
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.defaults import Defaults
 
 
@@ -28,6 +29,7 @@ def main():
     Report overall service status in an update to /etc/issue
     if not all services were successful
     """
+    Logger.setup()
     service_reports = Defaults.get_service_reports()
 
     failed_services = []

--- a/azure_li_services/units/storage.py
+++ b/azure_li_services/units/storage.py
@@ -20,6 +20,7 @@ import humanfriendly
 import shutil
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
@@ -39,6 +40,7 @@ def main():
     Updates fstab with new storage mount entries and activates
     them in the scope of an Azure Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('storage')
     config = RuntimeConfig(Defaults.get_config_file())
     storage_config = config.get_storage_config()

--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -21,6 +21,7 @@ import re
 from psutil import virtual_memory
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.command import Command
@@ -38,6 +39,7 @@ def main():
 
     Runs machine setup tasks in the scope of an Azure Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('system_setup')
     config = RuntimeConfig(Defaults.get_config_file())
     hostname = config.get_hostname()

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -20,6 +20,7 @@ import pwd
 import grp
 
 # project
+from azure_li_services.logger import Logger
 from azure_li_services.runtime_config import RuntimeConfig
 from azure_li_services.defaults import Defaults
 from azure_li_services.users import Users
@@ -41,6 +42,7 @@ def main():
     Creates the configured user and its access setup for ssh
     and sudo services in the scope of an Azure Li/Vli instance
     """
+    Logger.setup()
     status = StatusReport('user')
     config = RuntimeConfig(Defaults.get_config_file())
 

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,0 +1,18 @@
+import io
+
+from unittest.mock import (
+    patch, MagicMock
+)
+
+from azure_li_services.logger import Logger
+
+
+class TestLogger:
+    def test_setup(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            logger = Logger()
+            logger.setup()
+            mock_open.assert_called_once_with(
+                '/var/log/azure-li-services.log', 'a', encoding=None
+            )

--- a/test/unit/units/call_test.py
+++ b/test/unit/units/call_test.py
@@ -5,13 +5,14 @@ from azure_li_services.units.call import main
 
 
 class TestCall(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.call.Defaults.get_config_file')
     @patch('azure_li_services.units.call.StatusReport')
     @patch('azure_li_services.defaults.Defaults.mount_config_source')
     def test_main(
         self, mock_mount_config_source, mock_StatusReport,
-        mock_get_config_file, mock_Command_run
+        mock_get_config_file, mock_Command_run, mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status

--- a/test/unit/units/cleanup_test.py
+++ b/test/unit/units/cleanup_test.py
@@ -6,13 +6,14 @@ from azure_li_services.units.cleanup import main
 
 
 class TestCleanup(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.cleanup.Defaults.get_service_reports')
     @patch('azure_li_services.units.cleanup.Defaults.mount_config_source')
     @patch('azure_li_services.units.cleanup.Defaults.umount_config_source')
     def test_main(
         self, mock_umount_config_source, mock_mount_config_source,
-        mock_get_service_reports, mock_Command_run
+        mock_get_service_reports, mock_Command_run, mock_logger_setup
     ):
         report = Mock()
         report.get_state.return_value = True
@@ -71,6 +72,11 @@ class TestCleanup(object):
                     [
                         'bash', '-c',
                         'systemctl status -l --all &> lun_location/workload.log'
+                    ], raise_on_error=False
+                ),
+                call(
+                    [
+                        'cp', '/var/log/azure-li-services.log', 'lun_location'
                     ], raise_on_error=False
                 ),
                 call(

--- a/test/unit/units/config_lookup_test.py
+++ b/test/unit/units/config_lookup_test.py
@@ -7,6 +7,7 @@ from azure_li_services.exceptions import AzureHostedConfigFileNotFoundException
 
 
 class TestConfigLookup(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.path.Path.create')
     @patch('azure_li_services.path.Path.which')
@@ -15,7 +16,7 @@ class TestConfigLookup(object):
     @patch('os.chmod')
     def test_main(
         self, mock_chmod, mock_mount_config_source, mock_StatusReport,
-        mock_Path_which, mock_Path_create, mock_Command_run
+        mock_Path_which, mock_Path_create, mock_Command_run, mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status
@@ -45,13 +46,14 @@ class TestConfigLookup(object):
             [mock_mount_config_source.return_value.location]
         )
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.path.Path.which')
     @patch('azure_li_services.units.config_lookup.StatusReport')
     @patch('azure_li_services.defaults.Defaults.mount_config_source')
     def test_main_raises(
         self, mock_mount_config_source, mock_StatusReport,
-        mock_Path_which, mock_Command_run
+        mock_Path_which, mock_Command_run, mock_logger_setup
     ):
         mock_Path_which.return_value = None
         with raises(AzureHostedConfigFileNotFoundException):

--- a/test/unit/units/install_test.py
+++ b/test/unit/units/install_test.py
@@ -5,6 +5,7 @@ from azure_li_services.units.install import main
 
 
 class TestInstall(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.install.Defaults.get_config_file')
     @patch('azure_li_services.units.install.Path.create')
@@ -15,7 +16,7 @@ class TestInstall(object):
     def test_main(
         self, mock_os_path_isdir, mock_iglob, mock_mount_config_source,
         mock_StatusReport, mock_Path_create, mock_get_config_file,
-        mock_Command_run
+        mock_Command_run, mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status

--- a/test/unit/units/machine_constraints_test.py
+++ b/test/unit/units/machine_constraints_test.py
@@ -8,13 +8,14 @@ from azure_li_services.exceptions import AzureHostedException
 
 
 class TestMachineConstraints(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.machine_constraints.Defaults.get_config_file')
     @patch('azure_li_services.units.machine_constraints.StatusReport')
     @patch('multiprocessing.cpu_count')
     @patch('azure_li_services.units.machine_constraints.virtual_memory')
     def test_main(
         self, mock_virtual_memory, mock_cpu_count,
-        mock_StatusReport, mock_get_config_file
+        mock_StatusReport, mock_get_config_file, mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status

--- a/test/unit/units/network_test.py
+++ b/test/unit/units/network_test.py
@@ -10,12 +10,13 @@ from azure_li_services.exceptions import (
 
 
 class TestNetwork(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.network.AzureHostedNetworkSetup')
     @patch('azure_li_services.units.network.Defaults.get_config_file')
     @patch('azure_li_services.units.network.StatusReport')
     def test_main_li_vli_network(
         self, mock_StatusReport, mock_get_config_file,
-        mock_AzureHostedNetworkSetup
+        mock_AzureHostedNetworkSetup, mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status
@@ -33,10 +34,11 @@ class TestNetwork(object):
         with raises(AzureHostedException):
             main()
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.network.Defaults.get_config_file')
     @patch('azure_li_services.units.network.StatusReport')
     def test_main_vli_gen3_network(
-        self, mock_StatusReport, mock_get_config_file
+        self, mock_StatusReport, mock_get_config_file, mock_logger_setup
     ):
         mock_get_config_file.return_value = '../data/config_vli_gen3.yaml'
         with raises(AzureHostedNetworkConfigDataException):

--- a/test/unit/units/report_test.py
+++ b/test/unit/units/report_test.py
@@ -6,8 +6,9 @@ from azure_li_services.units.report import main
 
 
 class TestReport(object):
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.report.Defaults.get_service_reports')
-    def test_main(self, mock_get_service_reports):
+    def test_main(self, mock_get_service_reports, mock_logger_setup):
         report = Mock()
         report.get_systemd_service.return_value = 'service-name'
         report.get_state.return_value = False

--- a/test/unit/units/storage_test.py
+++ b/test/unit/units/storage_test.py
@@ -12,6 +12,7 @@ class TestStorage(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.storage.RuntimeConfig')
     @patch('azure_li_services.units.storage.Defaults.get_config_file')
@@ -20,7 +21,8 @@ class TestStorage(object):
     @patch('azure_li_services.units.storage.Path.create')
     def test_main(
         self, mock_Path_create, mock_disk_usage, mock_StatusReport,
-        mock_get_config_file, mock_RuntimConfig, mock_Command_run
+        mock_get_config_file, mock_RuntimConfig, mock_Command_run,
+        mock_logger_setup
     ):
         disk_usage = Mock()
         disk_usage.free = humanfriendly.parse_size('112G', binary=True)
@@ -45,11 +47,13 @@ class TestStorage(object):
             with raises(AzureHostedException):
                 main()
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.storage.RuntimeConfig')
     @patch('azure_li_services.units.storage.Defaults.get_config_file')
     @patch('azure_li_services.units.storage.StatusReport')
     def test_main_raises(
-        self, mock_StatusReport, mock_get_config_file, mock_RuntimConfig
+        self, mock_StatusReport, mock_get_config_file, mock_RuntimConfig,
+        mock_logger_setup
     ):
         config = Mock()
         config.get_storage_config.return_value = [{}]

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -21,6 +21,7 @@ class TestSystemSetup(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch.object(system_setup, 'enable_extra_kernel_modules')
     @patch.object(system_setup, 'set_hostname')
     @patch.object(system_setup, 'set_stonith_service')
@@ -37,7 +38,8 @@ class TestSystemSetup(object):
         mock_set_energy_performance_settings,
         mock_set_kernel_samepage_merging_mode,
         mock_set_kdump_service, mock_set_stonith_service,
-        mock_set_hostname, mock_extra_modules
+        mock_set_hostname, mock_extra_modules,
+        mock_logger_setup
     ):
         status = Mock()
         mock_StatusReport.return_value = status

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -15,6 +15,7 @@ class TestUser(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.user.Command.run')
     @patch('azure_li_services.defaults.Defaults.mount_config_source')
     @patch('azure_li_services.units.user.Defaults.get_config_file')
@@ -32,7 +33,7 @@ class TestUser(object):
         mock_path_exists, mock_StatusReport, mock_Path_create,
         mock_Users, mock_RuntimConfig, mock_get_config_file,
         mock_mount_config_source,
-        mock_Command_run
+        mock_Command_run, mock_logger_setup
     ):
         group_exists = [True, False, False]
         user_exists = [True, True, True, False]
@@ -180,11 +181,13 @@ class TestUser(object):
                 system_users.group_add.side_effect = Exception
                 main()
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.user.Defaults.get_config_file')
     @patch('azure_li_services.units.user.RuntimeConfig')
     @patch('azure_li_services.units.user.StatusReport')
     def test_main_raises_on_missing_credentials(
-        self, mock_StatusReport, mock_RuntimConfig, mock_get_config_file
+        self, mock_StatusReport, mock_RuntimConfig, mock_get_config_file,
+        mock_logger_setup
     ):
         config = Mock()
         config.get_user_config.return_value = None
@@ -192,11 +195,13 @@ class TestUser(object):
         with raises(AzureHostedUserConfigDataException):
             main()
 
+    @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.user.Defaults.get_config_file')
     @patch('azure_li_services.units.user.RuntimeConfig')
     @patch('azure_li_services.units.user.StatusReport')
     def test_main_raises_on_incomplete_credentials(
-        self, mock_StatusReport, mock_RuntimConfig, mock_get_config_file
+        self, mock_StatusReport, mock_RuntimConfig, mock_get_config_file,
+        mock_logger_setup
     ):
         config = Mock()
         config.get_user_config.return_value = [{}]


### PR DESCRIPTION
Add a log file /var/log/azure-li-services.log which adds
logging information from the service process. Usually error
log information is present on the systemd level but for
checking the process, it's calls and potential further information
it's also useful to have a processing log file. The log file
will be created on the host and gets also copied to the config
lun in the same way as the systemd workload log