### PR TITLE
Restart iscsi subsystem after device discovery

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -240,6 +240,12 @@ def set_stonith_service(config):
             ['rescan-scsi-bus.sh']
         )
         Command.run(
+            ['systemctl', 'restart', 'iscsi']
+        )
+        Command.run(
+            ['systemctl', 'restart', 'iscsid']
+        )
+        Command.run(
             ['sbd', '-d', target_device, 'create']
         )
         Command.run(

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -306,6 +306,12 @@ class TestSystemSetup(object):
                     ['rescan-scsi-bus.sh']
                 ),
                 call(
+                    ['systemctl', 'restart', 'iscsi']
+                ),
+                call(
+                    ['systemctl', 'restart', 'iscsid']
+                ),
+                call(
                     [
                         'sbd', '-d',
                         '/dev/disk/by-path/ip-10.20.253.31:3260-iscsi-iqn.'


### PR DESCRIPTION
Only after restart of the iscsi subsystem the device nodes
from a previous device discovery gets created properly.
This Fixes #170