### PR TITLE
Change the setup of the login shell

### DIFF
--- a/azure_li_services/schema.py
+++ b/azure_li_services/schema.py
@@ -166,6 +166,10 @@ schema = {
                     'required': False,
                     'type': 'string'
                 },
+                'loginshell': {
+                    'required': False,
+                    'type': 'string'
+                },
                 'ssh-key': {
                     'required': False,
                     'type': 'string'

--- a/azure_li_services/units/user.py
+++ b/azure_li_services/units/user.py
@@ -105,12 +105,11 @@ def create_or_modify_user(user):
         ]
     if 'shadow_hash' in user:
         user_options += [
-            '-p', user['shadow_hash'],
-            '-s', '/bin/bash'
+            '-p', user['shadow_hash']
         ]
-    elif 'ssh-key' in user:
+    if 'loginshell' in user:
         user_options += [
-            '-s', '/bin/bash'
+            '-s', user['loginshell']
         ]
     else:
         user_options += [

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -44,6 +44,7 @@ credentials:
     ssh-key: "ssh-rsa foo"
     ssh-private-key: "path/to/private/key/id_dsa"
     require_password_change: true
+    loginshell: "/bin/bash"
   -
     username: rpc
     id: 495
@@ -55,6 +56,7 @@ credentials:
     username: root
     shadow_hash: "sha-512-cipher"
     ssh-key: "ssh-rsa foo"
+    loginshell: "/bin/bash"
   -
     username: nopasslogin
     ssh-key: "ssh-rsa foo"

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -52,7 +52,8 @@ class TestRuntimeConfig(object):
                 'username': 'hanauser',
                 'shadow_hash': 'sha-512-cipher',
                 'ssh-private-key': 'path/to/private/key/id_dsa',
-                'require_password_change': True
+                'require_password_change': True,
+                'loginshell': '/bin/bash'
             },
             {
                 'group': {
@@ -66,7 +67,8 @@ class TestRuntimeConfig(object):
             {
                 'ssh-key': 'ssh-rsa foo',
                 'username': 'root',
-                'shadow_hash': 'sha-512-cipher'
+                'shadow_hash': 'sha-512-cipher',
+                'loginshell': '/bin/bash'
             },
             {
                 'ssh-key': 'ssh-rsa foo',

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -82,7 +82,7 @@ class TestUser(object):
                     'root', ['-p', 'sha-512-cipher', '-s', '/bin/bash']
                 ),
                 call(
-                    'nopasslogin', ['-s', '/bin/bash']
+                    'nopasslogin', ['-s', '/sbin/nologin']
                 )
             ]
             system_users.setup_change_password_on_logon.assert_called_once_with(


### PR DESCRIPTION
The login shell was setup based on assumption regarding other
user attributes set. This way caused some negative side effects
which lets us change the behavior. This patch does the following

* Adds a new attribute named: loginshell
* If loginshell is present the value for loginshell will be used,
  if not the default /sbin/nologin applies
* All implicit assumptions for setting up the login shell
  got deleted

This Fixes #178