### PR TITLE
Right sequence saptune

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -120,26 +120,12 @@ def set_saptune_service():
     profile = 'sapconf'
     if os.path.exists('/usr/lib/tuned/sap-hana'):
         profile = 'sap-hana'
-    Command.run(
-        ['saptune', 'daemon', 'start']
-    )
+
     Command.run(
         ['tuned-adm', 'profile', profile]
     )
     Command.run(
-        ['systemctl', 'start', 'tuned']
-    )
-    Command.run(
-        ['systemctl', 'enable', 'tuned']
-    )
-    Command.run(
-        ['tuned-adm', 'profile', profile]
-    )
-    Command.run(
-        ['saptune', 'solution', 'apply', 'HANA']
-    )
-    Command.run(
-        ['saptune', 'daemon', 'start']
+        ['systemctl', 'enable', '--now', 'sapconf.service']
     )
 
 

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -198,25 +198,15 @@ class TestSystemSetup(object):
         mock_os_path_exists.return_value = True
         system_setup.set_saptune_service()
         assert mock_Command_run.call_args_list == [
-            call(['saptune', 'daemon', 'start']),
             call(['tuned-adm', 'profile', 'sap-hana']),
-            call(['systemctl', 'start', 'tuned']),
-            call(['systemctl', 'enable', 'tuned']),
-            call(['tuned-adm', 'profile', 'sap-hana']),
-            call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['saptune', 'daemon', 'start'])
+            call(['systemctl', 'enable', '--now', 'sapconf.service'])
         ]
         mock_os_path_exists.return_value = False
         mock_Command_run.reset_mock()
         system_setup.set_saptune_service()
         assert mock_Command_run.call_args_list == [
-            call(['saptune', 'daemon', 'start']),
             call(['tuned-adm', 'profile', 'sapconf']),
-            call(['systemctl', 'start', 'tuned']),
-            call(['systemctl', 'enable', 'tuned']),
-            call(['tuned-adm', 'profile', 'sapconf']),
-            call(['saptune', 'solution', 'apply', 'HANA']),
-            call(['saptune', 'daemon', 'start'])
+            call(['systemctl', 'enable', '--now', 'sapconf.service'])
         ]
 
     @patch('azure_li_services.command.Command.run')


### PR DESCRIPTION
One of the issues is that `saptune` is a different tool that supersedes
`sapconf`. Then the `saptune daemon restart` command will always
overwrite the profile with `saptune`. Two different tools that can't be
mixed. Only one should be used.

In case of SLES (not SLES for SAP), the sequence should be
For SLES 12
```
tuned-adm profile sap-hana
systemctl enable --now sapconf.service
```
and for SLES15
```
tuned-adm profile sapconf
systemctl enable --now sapconf.service
```
For SLES for SAP, the sequence is the same for 12 and 15:
```
saptune daemon start
saptune solution apply HANA
```

This Fixes #172