### PR TITLE
Align image version to services version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,3 +5,15 @@ tag = True
 
 [bumpversion:file:azure_li_services/version.py]
 
+[bumpversion:file:images/li/sle12_sp4/config.kiwi]
+[bumpversion:file:images/li/sle15_sp1/config.kiwi]
+[bumpversion:file:images/li/sle12_sp5/config.kiwi]
+[bumpversion:file:images/li/sle12_sp3/config.kiwi]
+[bumpversion:file:images/li/sle15_sp2/config.kiwi]
+[bumpversion:file:images/li/sle15_ga/config.kiwi]
+[bumpversion:file:images/vli/sle12_sp4/config.kiwi]
+[bumpversion:file:images/vli/sle15_sp1/config.kiwi]
+[bumpversion:file:images/vli/sle12_sp5/config.kiwi]
+[bumpversion:file:images/vli/sle12_sp3/config.kiwi]
+[bumpversion:file:images/vli/sle15_sp2/config.kiwi]
+[bumpversion:file:images/vli/sle15_ga/config.kiwi]

--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.56</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.9</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.9</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.54</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.21</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.21</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.5</version>
+        <version>1.2.4</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>


### PR DESCRIPTION
The version set on the images was more or less an individual
setting by the author of the description and was very different
compared to the list of image descriptions. In addition the
version information was meaningless with regards to the installed
azure-li-services package. The image as it gets deployed runs
the deployment services as they are implemented in the
azure-li-services package and thus having this version
information populated and controlled in the image files will
give the image version a better meaning. Also image descriptions
and services code is managed in the same git repository. On the
development side a submission of the azure-li-services package
automatically triggers the rebuild of all images to include that
package. Therefore managing only one version for development is
telling the truth and should be part of the image descriptions.
For maintenance the image descriptions has to be copied from
the git into the SUSE namespace because remote services are
not allowed there. At this point in time an osc diff prior to
the checkin is needed anyway and should also be used double
check that the image version reflects the correct azure-li-services
in that SUSE namespace. This checkup will also ensure the
expected azure-li-services version is really in use. With the
former concept we just increased a number without any value.