### PR TITLE
Set OBS-ExclusiveArch in all image descriptions

### DIFF
--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP3-SAP-Azure-LI-BYOS" displayname="SLES12-SP3-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP4-SAP-Azure-LI-BYOS" displayname="SLES12-SP4-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP5-SAP-Azure-LI-BYOS" displayname="SLES12-SP5-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SAP-Azure-LI-BYOS" displayname="SLES15-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SP1-SAP-Azure-LI-BYOS" displayname="SLES15-SP1-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SP2-SAP-Azure-LI-BYOS" displayname="SLES15-SP2-SAP-Azure-LI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP3-SAP-Azure-VLI-BYOS" displayname="SLES12-SP3-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP4-SAP-Azure-VLI-BYOS" displayname="SLES12-SP4-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES12-SP5-SAP-Azure-VLI-BYOS" displayname="SLES12-SP5-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SAP-Azure-VLI-BYOS" displayname="SLES15-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SP1-SAP-Azure-VLI-BYOS" displayname="SLES15-SP1-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -2,7 +2,7 @@
 
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
+<!-- OBS-ExclusiveArch: x86_64 -->
 <image schemaversion="6.2" name="SLES15-SP2-SAP-Azure-VLI-BYOS" displayname="SLES15-SP2-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>


### PR DESCRIPTION
Images for the Azure LI/VLI target are exclusive to the
x86_64 architecture. This should be expressed in the image
such that the OBS team knows it and no extra resources
are wasted by building for other architectures