### PR TITLE
Added obs github service integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ variables:
 update_obs_services:
   image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
   stage: obs
+  only:
+    - master
   script:
     - base64 --decode "$HOP_HOST_SECRET" > id_hop_host
     - chmod 600 id_hop_host

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+stages:
+  - obs
+
+variables:
+  BUILD_IMAGES_PROJECT: azure-li/azure-li-ci-containers
+  TUMBLEWEED_BUILD: buildenv-tumbleweed
+
+update_obs_services:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
+  stage: obs
+  script:
+    - base64 --decode "$HOP_HOST_SECRET" > id_hop_host
+    - chmod 600 id_hop_host
+    - ssh -o StrictHostKeyChecking=no -i id_hop_host $(echo "$HOP_HOST" | base64 --decode) 2>/dev/null


### PR DESCRIPTION
Changes in the image descriptions hosted on github will
not automatically update the service in obs. This commit
adds a pipeline to run the service update from a hop
host that allows for only the service refresh command
through ssh