### PR TITLE
Set link naming policy instead of rule rewrite

### DIFF
--- a/images/li/sle12_sp3/config.sh
+++ b/images/li/sle12_sp3/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/li/sle12_sp3/root/usr/lib/systemd/network/81-mac-link
+++ b/images/li/sle12_sp3/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/li/sle12_sp3/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle12_sp3/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/li/sle12_sp4/config.sh
+++ b/images/li/sle12_sp4/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/li/sle12_sp4/root/usr/lib/systemd/network/81-mac-link
+++ b/images/li/sle12_sp4/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/li/sle12_sp4/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle12_sp4/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/li/sle12_sp5/config.sh
+++ b/images/li/sle12_sp5/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/li/sle12_sp5/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle12_sp5/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/li/sle15_ga/config.sh
+++ b/images/li/sle15_ga/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig /etc/sysconfig/bootloader LOADER_TYPE grub2

--- a/images/li/sle15_ga/root/usr/lib/systemd/network/81-mac-link
+++ b/images/li/sle15_ga/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/li/sle15_ga/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle15_ga/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/li/sle15_sp1/root/usr/lib/systemd/network/81-mac-link
+++ b/images/li/sle15_sp1/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/li/sle15_sp1/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle15_sp1/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/li/sle15_sp2/root/usr/lib/systemd/network/81-mac-link
+++ b/images/li/sle15_sp2/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/li/sle15_sp2/root/usr/lib/systemd/network/99-default.link
+++ b/images/li/sle15_sp2/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle12_sp3/config.sh
+++ b/images/vli/sle12_sp3/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle12_sp3/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle12_sp3/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle12_sp3/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle12_sp3/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle12_sp4/config.sh
+++ b/images/vli/sle12_sp4/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle12_sp4/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle12_sp4/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle12_sp4/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle12_sp4/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle12_sp5/config.sh
+++ b/images/vli/sle12_sp5/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle12_sp5/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle12_sp5/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle12_sp5/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle12_sp5/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle15_ga/config.sh
+++ b/images/vli/sle15_ga/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle15_ga/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle15_ga/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle15_ga/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle15_ga/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle15_sp1/config.sh
+++ b/images/vli/sle15_sp1/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle15_sp1/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle15_sp1/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle15_sp1/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle15_sp1/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent

--- a/images/vli/sle15_sp2/config.sh
+++ b/images/vli/sle15_sp2/config.sh
@@ -39,13 +39,6 @@ popd
 suseImportBuildKey
 
 #=========================================
-# Delete persistent-net.rules
-#-----------------------------------------
-# Avoid recreation of interface names at each boot
-# This goes along with net.ifnames=1
-rm -f /etc/udev/rules.d/70-persistent-net.rules
-
-#=========================================
 # Set sysconfig options
 #-----------------------------------------
 baseUpdateSysConfig \

--- a/images/vli/sle15_sp2/root/usr/lib/systemd/network/81-mac-link
+++ b/images/vli/sle15_sp2/root/usr/lib/systemd/network/81-mac-link
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=mac

--- a/images/vli/sle15_sp2/root/usr/lib/systemd/network/99-default.link
+++ b/images/vli/sle15_sp2/root/usr/lib/systemd/network/99-default.link
@@ -1,0 +1,3 @@
+[Link]
+NamePolicy=mac
+MACAddressPolicy=persistent


### PR DESCRIPTION
Instead of rewriting all network interface names in a udev
rule set the mac based network link policy in systemd
This Fixes #167