### PR TITLE
Add obs artificats

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,3 +14,14 @@ update_obs_services:
     - base64 --decode "$HOP_HOST_SECRET" > id_hop_host
     - chmod 600 id_hop_host
     - ssh -o StrictHostKeyChecking=no -i id_hop_host $(echo "$HOP_HOST" | base64 --decode) 2>/dev/null
+
+create_obs_static_data:
+  image: $CI_REGISTRY/$BUILD_IMAGES_PROJECT:$TUMBLEWEED_BUILD
+  stage: obs
+  only:
+    - master
+  script:
+    - ./obs_static.sh
+  artifacts:
+    paths:
+      - obs

--- a/obs_static.sh
+++ b/obs_static.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mkdir -p obs
+
+for image_system in images/*;do
+    system=$(basename "${image_system}")
+    mkdir -p obs/"${system}"
+    cp -a "${image_system}"/* obs/"${system}"/
+    for image in obs/"${system}"/*;do
+        if [ -d "${image}/root" ];then
+            pushd "${image}/root"
+            sudo chown -R root:root .
+            tar -czf ../root.tar.gz *
+            popd
+            sudo rm -rf "${image}/root"
+        fi
+    done
+done


### PR DESCRIPTION
This pipeline job creates the static image files as they
would be needed in the obs system if a source service
is not allowed. This is usally the case for production
submissions. Thus the data on the artificats link in
gitlab now offers this data and can just be used to
drive these type of submissions