### PR TITLE
Added system-group-wheel for sle15

### DIFF
--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -85,6 +85,7 @@
         <package name="vim"/>
         <package name="which"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end jeos server -->
         <!-- basic functionality -->
         <package name="aaa_base-extras"/>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -167,6 +167,7 @@
         <package name="pkg-config"/>
         <package name="elfutils"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end packages needed for resolution in OBS -->
         <!-- end basic functionality -->
         <!-- user configuration tools -->

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -167,6 +167,7 @@
         <package name="pkg-config"/>
         <package name="elfutils"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end packages needed for resolution in OBS -->
         <!-- end basic functionality -->
         <!-- user configuration tools -->

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -171,6 +171,7 @@
         <package name="pkg-config"/>
         <package name="elfutils"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end packages needed for resolution in OBS -->
         <!-- end basic functionality -->
         <!-- user configuration tools -->

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -171,6 +171,7 @@
         <package name="pkg-config"/>
         <package name="elfutils"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end packages needed for resolution in OBS -->
         <!-- end basic functionality -->
         <!-- user configuration tools -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -167,6 +167,7 @@
         <package name="pkg-config"/>
         <package name="elfutils"/>
         <package name="udev"/>
+        <package name="system-group-wheel"/>
         <!-- end packages needed for resolution in OBS -->
         <!-- end basic functionality -->
         <!-- user configuration tools -->


### PR DESCRIPTION
In SLE15 the install of the wheel group is no longer part
of the standard installation. This commit adds the explicit
install of the wheel group in all sle15 image descriptions
This Fixes #214