### PR TITLE
Added rsyslog to sle15 images

### DIFF
--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -50,6 +50,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="chrony"/>
         <package name="dhcp-client"/>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -49,6 +49,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="dhcp-client"/>
         <package name="fontconfig"/>

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -49,6 +49,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="dhcp-client"/>
         <package name="fontconfig"/>

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -49,6 +49,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="dhcp-client"/>
         <package name="fontconfig"/>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -49,6 +49,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="dhcp-client"/>
         <package name="fontconfig"/>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -49,6 +49,7 @@
     <packages type="image">
         <!-- jeos server -->
         <package name="patterns-base-minimal_base"/>
+        <package name="rsyslog"/>
         <package name="blog"/>
         <package name="dhcp-client"/>
         <package name="fontconfig"/>


### PR DESCRIPTION
There was no syslog package in the sle15 image installed.
This lead to all kernel messages to be displayed on the
console. It became an issue with all the alua warning
messages that floods the console. This Fixes #202