### PR TITLE
Fix kdump memory allocation

### DIFF
--- a/azure_li_services/units/system_setup.py
+++ b/azure_li_services/units/system_setup.py
@@ -311,11 +311,18 @@ def _kdump_calibrate(high, low):
                 pass
             calibration_values[key] = int(value)
 
-        # update High value on machines with more than 1TB of main memory
+        bash_command = ' '.join(
+            ['lsblk', '|', 'grep', 'disk', '|', 'wc', '-l']
+        )
+        storage_luns = int(
+            Command.run(['bash', '-c', bash_command]).output
+        )
         machine_memory = virtual_memory()
-        machine_memory_tbytes = int(machine_memory.total / 1024**4)
-        if machine_memory_tbytes > 1:
-            calibration_values['High'] *= machine_memory_tbytes
+        memory_TB = max(1, machine_memory.total / 1024**4)
+
+        calibration_values['High'] = int(
+            calibration_values['High'] * memory_TB + (storage_luns / 2)
+        )
     return calibration_values
 
 

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -24,7 +24,7 @@
         <hwclock>utc</hwclock>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->


### PR DESCRIPTION
This patch is two fold

**Fixed High value calculation in kdump setup**
    
The High value should be calculated according to the recommendation from:
https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-tuning-kexec.html#sec-tuning-kexec-crashkernel. In addition we also take into account high memory systems which
recommends to add 2 bits for every 4 KB of RAM.This Fixes #203

**Update High value for kdump in VLI images**
    
Assume up to 16luns per machine and 224M High from kdumptool
calibration. This results in 232M which we set for the
very large instances as default now
