### PR TITLE
Added prometheus monitoring modules

### DIFF
--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -280,6 +280,9 @@
         <package name="zlib-devel"/>
         <package name="perl-TimeDate"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -281,6 +281,9 @@
         <package name="perl-TimeDate"/>
         <package name="dracut-kiwi-oem-repart"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->


### PR DESCRIPTION
As requested by jsc#SLE-10545, jsc#SLE-10902, jsc#SLE-10903,
jsc#ECO-817 and jsc#ECO-818. This commit adds the additional
monitoring modules for the LI and VLI images for SLE15-SP2.
As soon as the modules are available for older versions/SPs
we can add them there too