### PR TITLE
Added prometheus monitoring modules for SLE12

### DIFF
--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.57</version>
+        <version>1.0.58</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -304,6 +304,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.10</version>
+        <version>1.0.11</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -300,6 +300,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.10</version>
+        <version>1.0.11</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -298,6 +298,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.55</version>
+        <version>1.0.56</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -304,6 +304,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.22</version>
+        <version>0.0.23</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -304,6 +304,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.22</version>
+        <version>0.0.23</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -302,6 +302,9 @@
         <package name="perl-TimeDate"/>
         <package name="zlib"/>
         <package name="zlib-devel"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->


### PR DESCRIPTION
As requested by jsc#SLE-10545, jsc#SLE-10902, jsc#SLE-10903,
jsc#ECO-817 and jsc#ECO-818. This commit adds the additional
monitoring modules for the LI and VLI images for SLE12-SP3
and onward.