### PR TITLE
Move to rsyslog for SLE12 VLI images

### DIFF
--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -60,7 +60,7 @@
         <package name="findutils-locate"/>
         <package name="audit-libs"/>
         <package name="keyutils-libs"/>
-        <package name="syslog-ng"/>
+        <package name="rsyslog"/>
         <package name="libopenssl1_0_0"/>
         <package name="libssh2-1"/>
         <!-- add for kernel crash dump analysis -->

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -59,7 +59,7 @@
         <package name="findutils-locate"/>
         <package name="audit-libs"/>
         <package name="keyutils-libs"/>
-        <package name="syslog-ng"/>
+        <package name="rsyslog"/>
         <package name="libopenssl1_0_0"/>
         <package name="libssh2-1"/>
         <package name="patch"/>

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -59,7 +59,7 @@
         <package name="findutils-locate"/>
         <package name="audit-libs"/>
         <package name="keyutils-libs"/>
-        <package name="syslog-ng"/>
+        <package name="rsyslog"/>
         <package name="libopenssl1_0_0"/>
         <package name="libssh2-1"/>
         <package name="patch"/>


### PR DESCRIPTION
rsyslog is requested over syslog-ng for the VLI images
in SLE12. This Fixes #228