### PR TITLE
Update prometheus monitoring modules for SLE15

### DIFF
--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -290,6 +290,10 @@
         <package name="zlib"/>
         <package name="zlib-devel"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -272,6 +272,10 @@
         <package name="zlib-devel"/>
         <package name="perl-TimeDate"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -283,6 +283,7 @@
         <package name="prometheus-ha_cluster_exporter"/>
         <package name="prometheus-hanadb_exporter"/>
         <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -277,6 +277,10 @@
         <package name="perl-TimeDate"/>
         <package name="dracut-kiwi-oem-repart"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -277,6 +277,10 @@
         <package name="perl-TimeDate"/>
         <package name="dracut-kiwi-oem-repart"/>
         <package name="java-1_8_0-ibm"/>
+        <package name="prometheus-ha_cluster_exporter"/>
+        <package name="prometheus-hanadb_exporter"/>
+        <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -284,6 +284,7 @@
         <package name="prometheus-ha_cluster_exporter"/>
         <package name="prometheus-hanadb_exporter"/>
         <package name="prometheus-sap_host_exporter"/>
+        <package name="golang-github-prometheus-node_exporter"/>
     </packages>
     <packages type="bootstrap">
         <!-- products -->


### PR DESCRIPTION
As requested by jsc#SLE-10545, jsc#SLE-10902, jsc#SLE-10903,
jsc#ECO-817 and jsc#ECO-818. This commit update/adds the additional
monitoring modules for the LI and VLI images for SLE15-SP1/SP2
and GA