### PR TITLE
Fix printk timing issue

### DIFF
--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.58</version>
+        <version>1.0.59</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -24,7 +24,7 @@
         <hwclock>utc</hwclock>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="ext4" bootloader="grub2" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="ext4" bootloader="grub2" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="ext4" bootloader="grub2" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="ext4" bootloader="grub2" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -24,7 +24,7 @@
         <hwclock>utc</hwclock>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.56</version>
+        <version>1.0.57</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -24,7 +24,7 @@
         <hwclock>utc</hwclock>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" boot="oemboot/suse-SLES12" filesystem="xfs" bootloader="grub2" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.23</version>
+        <version>0.0.24</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.23</version>
+        <version>0.0.24</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->


### PR DESCRIPTION
This change adds 'loglevel=3' to the kernel command line.
This is needed as a workaround to handing console messages
as a kthread. In certain cases there colud be a process block
while printing console messages. One viable worksround is to
adjust the loglevel to '3' to only show messages for "error,
critical, alert, and emergency."