### PR TITLE
Fix motd SP version for SLE15 SP2 images

### DIFF
--- a/images/li/sle15_sp2/root/etc/motd
+++ b/images/li/sle15_sp2/root/etc/motd
@@ -1,4 +1,4 @@
-SUSE Linux Enterprise Server 15 SP1 for SAP Applications x86_64 (64-bit)
+SUSE Linux Enterprise Server 15 SP2 for SAP Applications x86_64 (64-bit)
 
 Please register this image using your existing SUSE entitlement.
 

--- a/images/vli/sle15_sp2/root/etc/motd
+++ b/images/vli/sle15_sp2/root/etc/motd
@@ -1,4 +1,4 @@
-SUSE Linux Enterprise Server 15 SP1 for SAP Applications x86_64 (64-bit)
+SUSE Linux Enterprise Server 15 SP2 for SAP Applications x86_64 (64-bit)
 
 Please register this image using your existing SUSE entitlement.
 


### PR DESCRIPTION
The SLE15 SP2 images still have the version listed in the motd
file as SLE15 SP1. This patch updates the motd to match the installed
SLE15 SP2 version