### PR TITLE
Switch images to use rpm-ndb

### DIFF
--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -75,6 +75,7 @@
         <package name="parted"/>
         <package name="plymouth"/>
         <package name="psmisc"/>
+        <package name="rpm-ndb"/>
         <package name="rsync"/>
         <package name="syslinux"/>
         <package name="systemd"/>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -75,6 +75,7 @@
         <package name="parted"/>
         <package name="plymouth"/>
         <package name="psmisc"/>
+        <package name="rpm-ndb"/>
         <package name="rsync"/>
         <package name="syslinux"/>
         <package name="systemd"/>


### PR DESCRIPTION
…d to

  Berkley DB and the SleepyCat license. Per request by SAP (jsc#PM-2071)