### PR TITLE
Added gcc7 to all LI/VLI images

### DIFF
--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -55,6 +55,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -55,6 +55,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -58,6 +58,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -55,6 +55,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -55,6 +55,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -56,6 +56,7 @@
         <package name="fonts-config"/>
         <package name="shim"/>
         <!-- requested by SAP Applications Configuration Guide for SAP HANA -->
+        <package name="gcc7"/>
         <package name="wireshark"/>
         <package name="findutils-locate"/>
         <package name="audit-libs"/>


### PR DESCRIPTION
In order to run SAP applications which were compiled with GCC 7.x
the OS image needs to provide the correct gcc version. This
Fixes #238 and Fixes #218