### PR TITLE
Added requested VLI kernel parameters

### DIFF
--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->


### PR DESCRIPTION
Some new kernel parameters due to a change of the hardware in the data center running the VLI images are needed. Provision
of the images to the new hardware is limited to the SLE15 code base. Thus only the SLE15 VLI images were changed

This Fixes #240 