### PR TITLE
Fix permissions in obs overlay tarball

### DIFF
--- a/obs_static.sh
+++ b/obs_static.sh
@@ -9,7 +9,8 @@ for image_system in images/*;do
     for image in obs/"${system}"/*;do
         if [ -d "${image}/root" ];then
             pushd "${image}/root"
-            sudo chown -R root:root .
+            find -type d | xargs chmod 0755
+            chkstat --system --root "$(pwd)" --set
             tar -czf ../root.tar.gz *
             popd
             sudo rm -rf "${image}/root"


### PR DESCRIPTION
the job artifacts packs directories with 0777 which
could cause problems in chkstat on the later build
process.