### PR TITLE
Explicitly activate multipath lookup

### DIFF
--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/li/sle15_ga/config.kiwi
+++ b/images/li/sle15_ga/config.kiwi
@@ -26,6 +26,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -35,6 +36,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/li/sle15_sp1/config.kiwi
+++ b/images/li/sle15_sp1/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/li/sle15_sp2/config.kiwi
+++ b/images/li/sle15_sp2/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/li/sle15_sp3/config.kiwi
+++ b/images/li/sle15_sp3/config.kiwi
@@ -27,6 +27,7 @@
         <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low" firmware="bios" bootpartition="false">
             <bootloader name="grub2"/>
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>2048</oem-swapsize>
             </oemconfig>
@@ -36,6 +37,7 @@
         <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 net.ifnames=1 mce=ignore_ce nomodeset numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=160M,high crashkernel=80M,low rd.kiwi.debug" firmware="bios" bootpartition="false">
             <bootloader name="grub2"/>
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>2048</oem-swapsize>
             </oemconfig>

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -25,6 +25,7 @@
     <preferences profiles="Production">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>
@@ -34,6 +35,7 @@
     <preferences profiles="Devel">
         <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <!-- swap size set to 2G -->
                 <oem-swapsize>2048</oem-swapsize>

--- a/images/vli/sle15_sp3/config.kiwi
+++ b/images/vli/sle15_sp3/config.kiwi
@@ -26,6 +26,7 @@
         <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <bootloader name="grub2" console="console"/>
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>2048</oem-swapsize>
             </oemconfig>
@@ -35,6 +36,7 @@
         <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <bootloader name="grub2" console="console"/>
             <oemconfig>
+                <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
                 <oem-swapsize>2048</oem-swapsize>
             </oemconfig>


### PR DESCRIPTION
All LI/VLI images runs from a SAN storage via redundant
storage paths managed by multipath. The implicit check
for eventually existing multipath devices uncovered a
potential race condition if the multipath maps appears
too late. This is related to Issue #255. As a consequence
a fix in kiwi was made OSInside/kiwi#1641 which checks
for multipath maps until they appear or fail if they
don't appear after a timeout. This change requires an
image that is designed to run in a multipath environment
to explicitly request it, which is done in this PR