### PR TITLE
Fixed nmi watchdog kernel option

### DIFF
--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.12</version>
+        <version>1.0.13</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" bootloader="grub2" bootloader_console="console" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/images/vli/sle15_sp3/config.kiwi
+++ b/images/vli/sle15_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -23,7 +23,7 @@
         <timezone>UTC</timezone>
     </preferences>
     <preferences profiles="Production">
-        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0" firmware="uefi" bootpartition="false">
             <bootloader name="grub2" console="console"/>
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>
@@ -33,7 +33,7 @@
         </type>
     </preferences>
     <preferences profiles="Devel">
-        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s Nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
+        <type image="oem" filesystem="xfs" initrd_system="dracut" kernelcmdline="splash=verbose loglevel=3 nomodeset net.ifnames=1 numa_balancing=disable transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 crashkernel=232M,high crashkernel=80M,low nohz=off skew_tick=1 intel_pstate=disable clocksource=tsc console=ttyS0,115200 disable_mtrr_trim tsc=reliable DefaultTimeoutStartSec=900s DefaultTimeoutStopSec=900s nmi_watchdog=0 rd.kiwi.debug" firmware="uefi" bootpartition="false">
             <bootloader name="grub2" console="console"/>
             <oemconfig>
                 <oem-multipath-scan>true</oem-multipath-scan>


### PR DESCRIPTION
The option Nmi_watchdog was used for all VLI SLE15 images.
But the correct option names is nmi_watchdog. This is
related to bsc#1180817