### PR TITLE
Added explicit libyui curses package for YaST

### DIFF
--- a/images/li/sle15_sp3/config.kiwi
+++ b/images/li/sle15_sp3/config.kiwi
@@ -16,7 +16,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -230,6 +230,7 @@
         <package name="yast2-users"/>
         <package name="yast2-xml"/>
         <package name="yast2-ycp-ui-bindings"/>
+        <package name="libyui-ncurses-pkg"/>
         <!-- end user configuration tools -->
         <!-- framework specific packages -->
         <package name="hyper-v"/>

--- a/images/vli/sle15_sp3/config.kiwi
+++ b/images/vli/sle15_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.9.2</version>
+        <version>0.9.3</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>
@@ -229,6 +229,7 @@
         <package name="yast2-users"/>
         <package name="yast2-xml"/>
         <package name="yast2-ycp-ui-bindings"/>
+        <package name="libyui-ncurses-pkg"/>
         <!-- end user configuration tools -->
         <!-- framework specific packages -->
         <package name="hyper-v"/>


### PR DESCRIPTION
Also on SLE15 SP3 an explicit selection for the YaST
UI interface is required. This fixes bsc#1182965