### PR TITLE
Use <!-- OBS-IgnorePackage: rpm --> in config.kiwi to handle rpm-ndb properly

### DIFF
--- a/images/li/sle15_sp3/config.kiwi
+++ b/images/li/sle15_sp3/config.kiwi
@@ -3,6 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
+<!-- OBS-IgnorePackage: rpm -->
 
 <image schemaversion="7.2" name="SLES15-SP3-SAP-Azure-LI-BYOS" displayname="SLES15-SP3-SAP-Azure-LI-BYOS">
     <description type="system">

--- a/images/vli/sle15_sp3/config.kiwi
+++ b/images/vli/sle15_sp3/config.kiwi
@@ -3,6 +3,8 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <!-- OBS-ExclusiveArch: x86_64 -->
+<!-- OBS-IgnorePackage: rpm -->
+
 <image schemaversion="7.2" name="SLES15-SP3-SAP-Azure-VLI-BYOS" displayname="SLES15-SP3-SAP-Azure-VLI-BYOS">
     <description type="system">
         <author>Public Cloud Team</author>


### PR DESCRIPTION
The autobuild team has recently implemented that feature in IBS.  Basically you add a line <!-- OBS-IgnorePackage: rpm --> to the config.kiwi that have rpm-ndb in their packages list and can live without the extra repository. reduces time in the scheduler spent in 15-SP3 by one third (removing one out of 3 repos ...)