### PR TITLE
Fix config settings inconsistencies

### DIFF
--- a/images/li/sle12_sp3/config.kiwi
+++ b/images/li/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.62</version>
+        <version>1.0.63</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle12_sp3/config.sh
+++ b/images/li/sle12_sp3/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/li/sle12_sp4/config.kiwi
+++ b/images/li/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.15</version>
+        <version>1.0.16</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle12_sp4/config.sh
+++ b/images/li/sle12_sp4/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/li/sle12_sp5/config.kiwi
+++ b/images/li/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.15</version>
+        <version>1.0.16</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/li/sle12_sp5/config.sh
+++ b/images/li/sle12_sp5/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/li/sle15_ga/config.sh
+++ b/images/li/sle15_ga/config.sh
@@ -56,17 +56,11 @@ if [ -f /etc/modprobe.d/unsupported-modules ];then
 fi
 
 # Set sysconfig for things that are not setup by default, net new
-echo 'CONSOLE_ENCODING="UTF-8"' >> /etc/sysconfig/console
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
 echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
-echo '
-# The YaST-internal identifier of the attached keyboard.
-#
-YAST_KEYBOARD="english-us,pc104"' >> /etc/sysconfig/keyboard
-# Multi NIC is handeled by the YaML config file parsed with azure-li-services
 
 # Configuration outside of sysconfig
 # Setup policy kit

--- a/images/li/sle15_ga/config.sh
+++ b/images/li/sle15_ga/config.sh
@@ -58,7 +58,6 @@ fi
 # Set sysconfig for things that are not setup by default, net new
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
-echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
 

--- a/images/li/sle15_sp1/config.sh
+++ b/images/li/sle15_sp1/config.sh
@@ -56,17 +56,11 @@ if [ -f /etc/modprobe.d/unsupported-modules ];then
 fi
 
 # Set sysconfig for things that are not setup by default, net new
-echo 'CONSOLE_ENCODING="UTF-8"' >> /etc/sysconfig/console
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
 echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
-echo '
-# The YaST-internal identifier of the attached keyboard.
-#
-YAST_KEYBOARD="english-us,pc104"' >> /etc/sysconfig/keyboard
-# Multi NIC is handeled by the YaML config file parsed with azure-li-services
 
 # Configuration outside of sysconfig
 # Setup policy kit

--- a/images/li/sle15_sp1/config.sh
+++ b/images/li/sle15_sp1/config.sh
@@ -58,7 +58,6 @@ fi
 # Set sysconfig for things that are not setup by default, net new
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
-echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
 

--- a/images/li/sle15_sp2/config.sh
+++ b/images/li/sle15_sp2/config.sh
@@ -56,17 +56,11 @@ if [ -f /etc/modprobe.d/unsupported-modules ];then
 fi
 
 # Set sysconfig for things that are not setup by default, net new
-echo 'CONSOLE_ENCODING="UTF-8"' >> /etc/sysconfig/console
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
 echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
-echo '
-# The YaST-internal identifier of the attached keyboard.
-#
-YAST_KEYBOARD="english-us,pc104"' >> /etc/sysconfig/keyboard
-# Multi NIC is handeled by the YaML config file parsed with azure-li-services
 
 # Configuration outside of sysconfig
 # Setup policy kit

--- a/images/li/sle15_sp2/config.sh
+++ b/images/li/sle15_sp2/config.sh
@@ -58,7 +58,6 @@ fi
 # Set sysconfig for things that are not setup by default, net new
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
-echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
 

--- a/images/li/sle15_sp3/config.sh
+++ b/images/li/sle15_sp3/config.sh
@@ -55,17 +55,11 @@ if [ -f /etc/modprobe.d/unsupported-modules ];then
 fi
 
 # Set sysconfig for things that are not setup by default, net new
-echo 'CONSOLE_ENCODING="UTF-8"' >> /etc/sysconfig/console
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
 echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
-echo '
-# The YaST-internal identifier of the attached keyboard.
-#
-YAST_KEYBOARD="english-us,pc104"' >> /etc/sysconfig/keyboard
-# Multi NIC is handeled by the YaML config file parsed with azure-li-services
 
 # Configuration outside of sysconfig
 # Setup policy kit

--- a/images/li/sle15_sp3/config.sh
+++ b/images/li/sle15_sp3/config.sh
@@ -57,7 +57,6 @@ fi
 # Set sysconfig for things that are not setup by default, net new
 echo 'CONSOLE_FONT="lat9w-16.psfu"' >> /etc/sysconfig/console
 echo 'CONSOLE_SCREENMAP="trivial"' >> /etc/sysconfig/console
-echo 'DEFAULT_TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
 echo 'HWCLOCK="-u"' >> /etc/sysconfig/clock
 echo 'UTC=true' >> /etc/sysconfig/clock
 

--- a/images/vli/sle12_sp3/config.kiwi
+++ b/images/vli/sle12_sp3/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.60</version>
+        <version>1.0.61</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp3/config.sh
+++ b/images/vli/sle12_sp3/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle12_sp4/config.kiwi
+++ b/images/vli/sle12_sp4/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.27</version>
+        <version>0.0.28</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp4/config.sh
+++ b/images/vli/sle12_sp4/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle12_sp5/config.kiwi
+++ b/images/vli/sle12_sp5/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>0.0.27</version>
+        <version>0.0.28</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle12_sp5/config.sh
+++ b/images/vli/sle12_sp5/config.sh
@@ -52,9 +52,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle15_ga/config.kiwi
+++ b/images/vli/sle15_ga/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.12</version>
+        <version>1.0.13</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_ga/config.sh
+++ b/images/vli/sle15_ga/config.sh
@@ -47,9 +47,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle15_sp1/config.kiwi
+++ b/images/vli/sle15_sp1/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.12</version>
+        <version>1.0.13</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_sp1/config.sh
+++ b/images/vli/sle15_sp1/config.sh
@@ -47,9 +47,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle15_sp2/config.kiwi
+++ b/images/vli/sle15_sp2/config.kiwi
@@ -15,7 +15,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_sp2/config.sh
+++ b/images/vli/sle15_sp2/config.sh
@@ -47,9 +47,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------

--- a/images/vli/sle15_sp3/config.kiwi
+++ b/images/vli/sle15_sp3/config.kiwi
@@ -17,7 +17,7 @@
         <profile name="Production" description="Production Image Build"/>
     </profiles>
     <preferences>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <locale>en_US</locale>

--- a/images/vli/sle15_sp3/config.sh
+++ b/images/vli/sle15_sp3/config.sh
@@ -47,9 +47,6 @@ baseUpdateSysConfig \
 baseUpdateSysConfig \
     /etc/sysconfig/security POLKIT_DEFAULT_PRIVS restrictive
 
-baseUpdateSysConfig \
-    /etc/sysconfig/storage USED_FS_LIST ext4
-
 #=========================================
 # Allow unsupported modules
 #-----------------------------------------


### PR DESCRIPTION
**Delete obsolete timezone setting**
    
This setting is done by kiwi via the respective timezone section


**Delete obsolete keyboard and console settings**
    
These settings are done by kiwi according to the locale and keyboard settings


**Delete inconsistent and wrong USED_FS_LIST setting**
    
For some reason, probably cut and paste an invalid setting in /etc/sysconfig/storage was applied

