### PR TITLE
Build setup changes

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Python${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install

--- a/package/azure-li-services-spec-template
+++ b/package/azure-li-services-spec-template
@@ -15,6 +15,12 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version} >= 1600
+%define pythons %{primary_python}
+%else
+%define pythons python3
+%endif
+%global _sitelibdir %{%{pythons}_sitelib}
 
 Name:             azure-li-services
 Version:          %%VERSION
@@ -25,14 +31,27 @@ License:          GPL-3.0+
 Group:            System/Management
 Source:           azure-li-services.tar.gz
 BuildRoot:        %{_tmppath}/%{name}-%{version}-build
-BuildRequires:    python3-devel
-BuildRequires:    python3-setuptools
+BuildRequires:    %{pythons}-devel
+BuildRequires:    %{pythons}-setuptools
+%if 0%{?suse_version} >= 1600
+BuildRequires:  %{pythons}-pip
+BuildRequires:  %{pythons}-wheel
+%endif
+BuildRequires:  python-rpm-macros
 BuildRequires:    systemd-rpm-macros
-Requires:         python3-PyYAML
-Requires:         python3-setuptools
-Requires:         python3-psutil
-Requires:         python3-humanfriendly
-Requires:         python3-Cerberus
+%if 0%{?suse_version} >= 1600
+Requires:         python-PyYAML
+Requires:         python-setuptools
+Requires:         python-psutil
+Requires:         python-humanfriendly
+Requires:         python-Cerberus
+%else
+Requires:         %{pythons}-PyYAML
+Requires:         %{pythons}-setuptools
+Requires:         %{pythons}-psutil
+Requires:         %{pythons}-humanfriendly
+Requires:         %{pythons}-Cerberus
+%endif
 Requires:         shadow
 Requires(preun):  systemd
 Requires(postun): systemd
@@ -54,10 +73,18 @@ phase of an Azure Large or Very Large Instance.
 %setup -q -n azure_li_services-%{version}
 
 %build
-python3 setup.py build
+%if 0%{?suse_version} >= 1600
+%pyproject_wheel
+%else
+%{pythons} setup.py build
+%endif
 
 %install
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%if 0%{?suse_version} >= 1600
+%pyproject_install
+%else
+%{pythons} setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%endif
 
 install -D -m 644 systemd/azure-li-config-lookup.service \
     %{buildroot}%{_unitdir}/azure-li-config-lookup.service
@@ -99,7 +126,7 @@ install -D -m 644 systemd/azure-li-system-setup.service \
 
 %files
 %defattr(-,root,root,-)
-%{python3_sitelib}/*
+%{_sitelibdir}/*
 
 %{_bindir}/azure-li-config-lookup
 %{_unitdir}/azure-li-config-lookup.service

--- a/pip.sh
+++ b/pip.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-pip install --upgrade pip
-pip install "$@"

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -14,5 +14,5 @@ class TestLogger:
             logger = Logger()
             logger.setup()
             mock_open.assert_called_once_with(
-                '/var/log/azure-li-services.log', 'a', encoding=None
+                '/var/log/azure-li-services.log', 'a', encoding='locale', errors=None
             )

--- a/test/unit/network_test.py
+++ b/test/unit/network_test.py
@@ -21,6 +21,9 @@ class TestAzureHostedNetworkSetup(object):
         self.network_config_bond_vlan = config_bond_vlan.get_network_config()
         self.network_config_vlan_bond = config_vlan_bond.get_network_config()
 
+    def setup_method(self, cls):
+        self.setup()
+
     def test_create_default_route_config(self):
         network = AzureHostedNetworkSetup(self.network_config[0])
         with patch('builtins.open', create=True) as mock_open:

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -10,6 +10,9 @@ class TestRuntimeConfig(object):
     def setup(self):
         self.runtime_config = RuntimeConfig('../data/config.yaml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('yaml.safe_load')
     def test_init_raises_on_invalid_format(self, mock_yaml_load):
         mock_yaml_load.side_effect = Exception

--- a/test/unit/status_report_test.py
+++ b/test/unit/status_report_test.py
@@ -36,6 +36,11 @@ class TestStatusReport(object):
                 call('\n')
             ]
 
+    @patch('os.path.exists')
+    @patch('azure_li_services.status_report.Path.create')
+    def setup_method(self, cls, mock_Path_create, mock_exists):
+        self.setup()
+
     def test_set_success(self):
         with patch('builtins.open', create=True) as mock_open:
             self.report.set_success()

--- a/test/unit/units/storage_test.py
+++ b/test/unit/units/storage_test.py
@@ -12,6 +12,9 @@ class TestStorage(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.command.Command.run')
     @patch('azure_li_services.units.storage.RuntimeConfig')

--- a/test/unit/units/system_setup_test.py
+++ b/test/unit/units/system_setup_test.py
@@ -28,6 +28,9 @@ class TestSystemSetup(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('azure_li_services.logger.Logger.setup')
     @patch.object(system_setup, 'enable_extra_kernel_modules')
     @patch.object(system_setup, 'set_hostname')

--- a/test/unit/units/user_test.py
+++ b/test/unit/units/user_test.py
@@ -15,6 +15,9 @@ class TestUser(object):
     def setup(self):
         self.config = RuntimeConfig('../data/config.yaml')
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('azure_li_services.logger.Logger.setup')
     @patch('azure_li_services.units.user.Command.run')
     @patch('azure_li_services.defaults.Defaults.mount_config_source')

--- a/test/unit/users_test.py
+++ b/test/unit/users_test.py
@@ -7,6 +7,9 @@ class TestUsers(object):
     def setup(self):
         self.users = Users()
 
+    def setup_method(self, cls):
+        self.setup()
+
     @patch('azure_li_services.users.Command.run')
     def test_user_exists(self, mock_command):
         self.users.user_exists('user')

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,6 @@ envlist =
 
 
 [testenv]
-install_command = {toxinidir}/pip.sh {opts} {packages}
-whitelist_externals =
-    /bin/bash
 basepython =
     {check}: python3
     unit_py3: python3
@@ -23,6 +20,7 @@ deps =
 
 # Unit Test run with basepython set to 3.x
 [testenv:unit_py3]
+allowlist_externals = bash
 skip_install = True
 usedevelop = True
 setenv =


### PR DESCRIPTION
Support build in SLE 16 using available Py macros. Keep previous builds unchanged, i.e. use the python3 symlink in SLE 15 and SLE 12.